### PR TITLE
Fix MultiSelector

### DIFF
--- a/MultiSelectorSample/App.axaml
+++ b/MultiSelectorSample/App.axaml
@@ -8,6 +8,6 @@
 
     <Application.Styles>
         <FluentTheme Mode="Light"/>
-        <StyleInclude Source="avares://MultiSelectorSample/Views/MultiSelector.axaml" />
+        <StyleInclude Source="avares://Zafiro.Avalonia/Controls/MultiSelector.axaml" />
     </Application.Styles>
 </Application>

--- a/MultiSelectorSample/ViewModels/MainWindowViewModel.cs
+++ b/MultiSelectorSample/ViewModels/MainWindowViewModel.cs
@@ -4,13 +4,11 @@ namespace MultiSelectorSample.ViewModels;
 
 public class MainWindowViewModel : ViewModelBase
 {
-    public string Greeting => "Welcome to Avalonia!";
-
     public MainWindowViewModel()
     {
-        Items = new List<ViewModel>
+        Items = new List<ViewModel>()
         {
-            new ViewModel(),
+            new ViewModel { IsSelected = true },
             new ViewModel(),
             new ViewModel(),
             new ViewModel(),

--- a/MultiSelectorSample/ViewModels/ViewModel.cs
+++ b/MultiSelectorSample/ViewModels/ViewModel.cs
@@ -1,5 +1,5 @@
-using MultiSelectorSample.Views;
 using ReactiveUI.Fody.Helpers;
+using Zafiro.Avalonia;
 
 namespace MultiSelectorSample.ViewModels;
 

--- a/MultiSelectorSample/Views/MainWindow.axaml
+++ b/MultiSelectorSample/Views/MainWindow.axaml
@@ -3,7 +3,7 @@
         xmlns:vm="using:MultiSelectorSample.ViewModels"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-        xmlns:views="clr-namespace:MultiSelectorSample.Views"
+        xmlns:controls="clr-namespace:Zafiro.Avalonia.Controls;assembly=Zafiro.Avalonia"
         mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
         x:Class="MultiSelectorSample.Views.MainWindow"
         Icon="/Assets/avalonia-logo.ico"
@@ -15,9 +15,9 @@
 
 	<StackPanel>
         <Label>MultiSelector</Label>
-        <views:MultiSelector Items="{Binding Items}" />
+        <controls:MultiSelector Items="{Binding Items}" />
 		<Label Margin="0 20 0 0">Collection</Label>
-		<ItemsControl  Items="{Binding Items}">
+		<ItemsControl Items="{Binding Items}">
 			<ItemsControl.ItemTemplate>
 				<DataTemplate>
 					<CheckBox IsChecked="{Binding IsSelected}" />

--- a/Zafiro.Avalonia/Controls/MultiSelector.axaml
+++ b/Zafiro.Avalonia/Controls/MultiSelector.axaml
@@ -1,6 +1,6 @@
 <Styles xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        xmlns:controls="using:MultiSelectorSample.Views">
+        xmlns:controls="clr-namespace:Zafiro.Avalonia.Controls">
   <Design.PreviewWith>
     <controls:MultiSelector />
   </Design.PreviewWith>

--- a/Zafiro.Avalonia/ISelectable.cs
+++ b/Zafiro.Avalonia/ISelectable.cs
@@ -1,6 +1,6 @@
 using System.ComponentModel;
 
-namespace MultiSelectorSample.Views;
+namespace Zafiro.Avalonia;
 
 public interface ISelectable : INotifyPropertyChanged
 {

--- a/Zafiro.Avalonia/Zafiro.Avalonia.csproj
+++ b/Zafiro.Avalonia/Zafiro.Avalonia.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
 		<TargetFramework>net6.0</TargetFramework>


### PR DESCRIPTION
Multi selector was restricted to work with `ReadOnlyObservableCollection<ISelectable>`.
Now, it accepts anything that implements `IEnumerable<T>`, and optionally `INotifyCollectionChanged`.