### PR TITLE
Introduce `SetAvaloniaPropertyCurrentValueAction`

### DIFF
--- a/src/Zafiro.Avalonia/Behaviors/AvaloniaParseHelper.cs
+++ b/src/Zafiro.Avalonia/Behaviors/AvaloniaParseHelper.cs
@@ -1,0 +1,36 @@
+using System.Collections.Concurrent;
+using System.Globalization;
+using System.Reflection;
+
+namespace Zafiro.Avalonia.Behaviors;
+
+public static class AvaloniaParseHelper
+{
+    private static readonly ConcurrentDictionary<Type, MethodInfo?> ParseMethods = new();
+
+    public static object? InvokeParse(string s, Type targetType)
+    {
+        if (s is null) throw new ArgumentNullException(nameof(s));
+        if (targetType is null) throw new ArgumentNullException(nameof(targetType));
+
+        var method = ParseMethods.GetOrAdd(targetType, t =>
+        {
+            var m = t.GetMethod(
+                "Parse",
+                BindingFlags.Public | BindingFlags.Static,
+                null,
+                [typeof(string), typeof(CultureInfo)],
+                null);
+            return m ?? t.GetMethod(
+                "Parse",
+                BindingFlags.Public | BindingFlags.Static,
+                null,
+                new[] { typeof(string) },
+                null);
+        });
+
+        return method?.Invoke(null, method.GetParameters().Length == 2
+            ? [s, CultureInfo.InvariantCulture]
+            : [s]);
+    }
+}

--- a/src/Zafiro.Avalonia/Behaviors/SetAvaloniaPropertyCurrentValueAction.cs
+++ b/src/Zafiro.Avalonia/Behaviors/SetAvaloniaPropertyCurrentValueAction.cs
@@ -1,0 +1,92 @@
+using System.ComponentModel;
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+using System.Reflection;
+using Avalonia.Xaml.Interactivity;
+
+namespace Zafiro.Avalonia.Behaviors;
+
+/// <summary>
+/// Sets the current value of an Avalonia property
+/// without overriding local bindings or animations.
+/// </summary>
+[RequiresUnreferencedCode("Incompatible with trimming.")]
+public class SetAvaloniaPropertyCurrentValueAction : StyledElementAction
+{
+    public static readonly StyledProperty<AvaloniaProperty?> TargetPropertyProperty =
+        AvaloniaProperty.Register<SetAvaloniaPropertyCurrentValueAction, AvaloniaProperty?>(nameof(TargetProperty));
+
+    public static readonly StyledProperty<AvaloniaObject?> TargetObjectProperty =
+        AvaloniaProperty.Register<SetAvaloniaPropertyCurrentValueAction, AvaloniaObject?>(nameof(TargetObject));
+
+    public static readonly StyledProperty<object?> ValueProperty =
+        AvaloniaProperty.Register<SetAvaloniaPropertyCurrentValueAction, object?>(nameof(Value));
+
+    public AvaloniaProperty? TargetProperty
+    {
+        get => GetValue(TargetPropertyProperty);
+        set => SetValue(TargetPropertyProperty, value);
+    }
+
+    [ResolveByName]
+    public AvaloniaObject? TargetObject
+    {
+        get => GetValue(TargetObjectProperty);
+        set => SetValue(TargetObjectProperty, value);
+    }
+
+    public object? Value
+    {
+        get => GetValue(ValueProperty);
+        set => SetValue(ValueProperty, value);
+    }
+
+    public override object Execute(object? sender, object? parameter)
+    {
+        if (!IsEnabled)
+            return false;
+
+        if (TargetProperty is null)
+            throw new ArgumentNullException(nameof(TargetProperty));
+
+        if ((TargetObject ?? sender as AvaloniaObject) is not AvaloniaObject target)
+            return false;
+
+        ApplyCurrentValue(target, TargetProperty);
+        return true;
+    }
+
+    void ApplyCurrentValue(AvaloniaObject target, AvaloniaProperty property)
+    {
+        if (property.IsReadOnly)
+            throw new ArgumentException($"Property {property.Name} is read-only.");
+
+        var converted = ConvertValue(Value, property.PropertyType);
+        target.SetCurrentValue(property, converted);
+    }
+
+    static object? ConvertValue(object? input, Type targetType)
+    {
+        if (input is null)
+            return targetType.GetTypeInfo().IsValueType
+                ? Activator.CreateInstance(targetType)
+                : null;
+
+        if (targetType.GetTypeInfo().IsAssignableFrom(input.GetType().GetTypeInfo()))
+            return input;
+
+        var text = input.ToString()!;
+
+        if (targetType.GetTypeInfo().IsEnum)
+            return Enum.Parse(targetType, text, ignoreCase: true);
+
+        if (typeof(IConvertible).GetTypeInfo().IsAssignableFrom(targetType.GetTypeInfo()))
+            return Convert.ChangeType(text, targetType, CultureInfo.InvariantCulture);
+
+        var converter = TypeDescriptor.GetConverter(targetType);
+        if (converter.CanConvertFrom(typeof(string)))
+            return converter.ConvertFromInvariantString(text);
+
+        return AvaloniaParseHelper.InvokeParse(text, targetType);
+    }
+}

--- a/src/Zafiro.Avalonia/Controls/Shell/ShellSplitView.axaml
+++ b/src/Zafiro.Avalonia/Controls/Shell/ShellSplitView.axaml
@@ -123,7 +123,7 @@
                                 <Interaction.Behaviors>
                                     <behaviors:PointerPressedOutsideTriggerBehavior
                                         IsEnabled="{Binding $parent[z:ShellSplitView].DisplayMode, Converter={x:Static shell:ShellConverters.IsOverlay}}">
-                                        <ChangeAvaloniaPropertyAction
+                                        <behaviors:SetAvaloniaPropertyCurrentValueAction
                                             TargetObject="{Binding $parent[z:ShellSplitView]}"
                                             TargetProperty="{x:Static z:ShellSplitView.IsPaneOpenProperty}"
                                             Value="{x:False}" />

--- a/src/Zafiro.Avalonia/Controls/Shell/ShellView.axaml
+++ b/src/Zafiro.Avalonia/Controls/Shell/ShellView.axaml
@@ -2,7 +2,8 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:sh="clr-namespace:Zafiro.Avalonia.Controls.Shell"
         xmlns:pt="https://github.com/projektanker/icons.avalonia"
-        xmlns:c="clr-namespace:Zafiro.Avalonia.Controls">
+        xmlns:c="clr-namespace:Zafiro.Avalonia.Controls"
+        xmlns:b="clr-namespace:Zafiro.Avalonia.Behaviors">
 
     <Design.PreviewWith>
         <sh:ShellView Width="400" Height="500">
@@ -47,10 +48,10 @@
                                 </sh:Sidebar.Transitions>
                                 <Interaction.Behaviors>
                                     <PointerReleasedTrigger EventRoutingStrategy="Tunnel">
-                                        <ChangeAvaloniaPropertyAction IsEnabled="{Binding $parent[c:ShellSplitView].DisplayMode, Converter={x:Static sh:ShellConverters.IsOverlay}}"
-                                                                      TargetObject="{Binding $parent[sh:ShellView]}"
-                                                                      Value="False"
-                                                                      TargetProperty="{x:Static sh:ShellView.IsPaneOpenProperty}" />
+                                        <b:SetAvaloniaPropertyCurrentValueAction IsEnabled="{Binding $parent[c:ShellSplitView].DisplayMode, Converter={x:Static sh:ShellConverters.IsOverlay}}"
+                                                                                 TargetObject="{Binding $parent[sh:ShellView]}"
+                                                                                 Value="False"
+                                                                                 TargetProperty="{x:Static sh:ShellView.IsPaneOpenProperty}" />
                                     </PointerReleasedTrigger>
                                 </Interaction.Behaviors>
                             </sh:Sidebar>
@@ -64,6 +65,21 @@
             <Style Selector="^ /template/ c|ShellSplitView.Wide">
                 <Setter Property="DisplayMode" Value="CompactInline" />
             </Style>
+            <!-- <Style Selector="^ /template/ c|ShellSplitView ContentPresenter#PaneContainer"> -->
+            <!--     <Setter Property="Interaction.Behaviors"> -->
+            <!--         <BehaviorCollectionTemplate> -->
+            <!--             <BehaviorCollection> -->
+            <!--                 <b:PointerPressedOutsideTriggerBehavior -->
+            <!--                     IsEnabled="{Binding $parent[c:ShellSplitView].DisplayMode, Converter={x:Static sh:ShellConverters.IsOverlay}}"> -->
+            <!--                     <ChangeAvaloniaPropertyAction -->
+            <!--                         TargetObject="{Binding $parent[sh:ShellView]}" -->
+            <!--                         TargetProperty="{x:Static sh:ShellView.IsPaneOpenProperty}" -->
+            <!--                         Value="False" /> -->
+            <!--                 </b:PointerPressedOutsideTriggerBehavior> -->
+            <!--             </BehaviorCollection> -->
+            <!--         </BehaviorCollectionTemplate> -->
+            <!--     </Setter> -->
+            <!-- </Style> -->
         </ControlTheme>
 
         <ControlTheme TargetType="sh:ShellView" x:Key="Old">


### PR DESCRIPTION
For precise property updates

Added `SetAvaloniaPropertyCurrentValueAction`, allowing updates to Avalonia properties without overriding local bindings or animations. Updated its integration in `ShellView.axaml` and `ShellSplitView.axaml`. Introduced `AvaloniaParseHelper` for parsing string to target types. Minor updates to XAML namespaces for better organization.