### PR TITLE
Introduce GitHub release automation and improve build configurability

### DIFF
--- a/.nuke/build.schema.json
+++ b/.nuke/build.schema.json
@@ -25,6 +25,7 @@
       "type": "string",
       "enum": [
         "Publish",
+        "PublishGitHubRelease",
         "PublishNugetPackages",
         "PublishSite",
         "RestoreWorkloads"
@@ -101,10 +102,41 @@
   "allOf": [
     {
       "properties": {
+        "AndroidSigningKeyAlias": {
+          "type": "string",
+          "description": "The alias for the key in the keystore"
+        },
+        "AndroidSigningKeyPass": {
+          "type": "string",
+          "description": "The password of the key within the keystore file",
+          "default": "Secrets must be entered via 'nuke :secrets [profile]'"
+        },
+        "AndroidSigningStorePass": {
+          "type": "string",
+          "description": "The password for the keystore file",
+          "default": "Secrets must be entered via 'nuke :secrets [profile]'"
+        },
+        "Base64Keystore": {
+          "type": "string",
+          "description": "Contents of the keystore encoded as Base64"
+        },
+        "Configuration": {
+          "type": "string",
+          "description": "Configuration to build - Default is 'Debug' (local) or 'Release' (server)",
+          "enum": [
+            "Debug",
+            "Release"
+          ]
+        },
         "Force": {
           "type": "boolean"
         },
         "GitHubApiKey": {
+          "type": "string",
+          "description": "GitHub Authentication Token",
+          "default": "Secrets must be entered via 'nuke :secrets [profile]'"
+        },
+        "GitHubAuthenticationToken": {
           "type": "string",
           "description": "GitHub Authentication Token",
           "default": "Secrets must be entered via 'nuke :secrets [profile]'"

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -26,7 +26,7 @@
     <PackageVersion Include="HttpClient.Extensions.LoggingHttpMessageHandler" Version="1.0.3" />
     <PackageVersion Include="JetBrains.Annotations" Version="2024.3.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-    <PackageVersion Include="Nuke.Common" Version="9.0.4" />
+    <PackageVersion Include="Nuke.Common" Version="8.1.4" />
     <PackageVersion Include="Projektanker.Icons.Avalonia" Version="9.6.2" />
     <PackageVersion Include="Projektanker.Icons.Avalonia.FontAwesome" Version="9.6.2" />
     <PackageVersion Include="Projektanker.Icons.Avalonia.MaterialDesign" Version="9.6.2" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -40,10 +40,11 @@
     <PackageVersion Include="xunit" Version="2.5.3" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="2.5.3" />
     <PackageVersion Include="Zafiro" Version="23.0.0" />
-    <PackageVersion Include="Zafiro.Deployment" Version="20.0.2" />
+    <PackageVersion Include="Zafiro.Deployment" Version="23.0.0" />
     <PackageVersion Include="Zafiro.FileSystem.Actions" Version="23.0.0" />
     <PackageVersion Include="Zafiro.FileSystem.Local" Version="23.0.0" />
     <PackageVersion Include="Zafiro.FileSystem.SeaweedFS" Version="23.0.0" />
+    <PackageVersion Include="Zafiro.Nuke" Version="1.0.10" />
     <PackageVersion Include="Zafiro.UI" Version="23.0.0" />
     <PackageVersion Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.26100.4188" />
   </ItemGroup>

--- a/build/Build.cs
+++ b/build/Build.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using CSharpFunctionalExtensions;
+using DotnetPackaging;
 using Nuke.Common;
 using Nuke.Common.Git;
 using Nuke.Common.ProjectModel;
@@ -10,16 +11,27 @@ using Nuke.Common.Tools.DotNet;
 using Nuke.Common.Tools.GitVersion;
 using Zafiro.Deployment;
 using Zafiro.Misc;
+using Zafiro.Nuke;
 using static Nuke.Common.Tools.DotNet.DotNetTasks;
+using Options = DotnetPackaging.Options;
 
 class Build : NukeBuild
 {
+    // Android
+    [Parameter("The alias for the key in the keystore.")] readonly string AndroidSigningKeyAlias;
+    [Parameter("The password of the key within the keystore file.")] [Secret] readonly string AndroidSigningKeyPass;
+    [Parameter("The password for the keystore file.")] [Secret] readonly string AndroidSigningStorePass;
+    [Parameter("Contents of the keystore encoded as Base64.")] readonly string Base64Keystore;
+    [Parameter("Configuration to build - Default is 'Debug' (local) or 'Release' (server)")] readonly Configuration Configuration = IsLocalBuild ? Configuration.Debug : Configuration.Release;
     [Parameter] readonly bool Force;
     [Parameter("GitHub Authentication Token")] [Secret] readonly string GitHubApiKey;
+    [Parameter("GitHub Authentication Token")] [Secret] readonly string GitHubAuthenticationToken;
     [GitVersion] readonly GitVersion GitVersion;
     [Parameter("NuGet Authentication Token")] [Secret] readonly string NuGetApiKey;
     [GitRepository] readonly GitRepository Repository;
     [Solution] readonly Solution Solution;
+
+    Actions Actions { get; set; }
 
     Target RestoreWorkloads => _ => _
         .Executes(() =>
@@ -59,14 +71,39 @@ class Build : NukeBuild
                 .LogInfo("Site published");
         });
 
+    Target PublishGitHubRelease => td => td
+        .OnlyWhenStatic(() => Repository.IsOnMainOrMasterBranch())
+        .Requires(() => GitHubAuthenticationToken)
+        .Executes(async () =>
+        {
+            await Solution.Projects
+                .TryFirst(x => x.GetOutputType().Contains("Exe", StringComparison.InvariantCultureIgnoreCase))
+                .ToResult("Could not find the executable project")
+                .Bind(project =>
+                {
+                    return new DeploymentBuilder(Actions, project)
+                        .ForLinux(Options())
+                        .ForWindows()
+                        .ForAndroid(Base64Keystore, AndroidSigningKeyAlias, AndroidSigningKeyPass, AndroidSigningStorePass)
+                        .Build()
+                        .Bind(paths => Actions.CreateGitHubRelease(GitHubAuthenticationToken, paths.ToArray()));
+                })
+                .TapError(err => throw new ApplicationException(err));
+        });
+
     Target Publish => td => td
-        .DependsOn(PublishNugetPackages, PublishSite);
+        .DependsOn(PublishNugetPackages, PublishSite, PublishGitHubRelease);
 
     IEnumerable<string> PackableProjects =>
         Solution.AllProjects
             .Where(x => x.GetProperty<bool>("IsPackable"))
             .Where(x => !(x.Path.ToString().Contains("Test", StringComparison.InvariantCultureIgnoreCase) || x.Path.ToString().Contains("Sample", StringComparison.InvariantCultureIgnoreCase)))
             .Select(x => x.Path.ToString());
+
+    protected override void OnBuildInitialized()
+    {
+        Actions = new Actions(Solution, Repository, RootDirectory, GitVersion, Configuration);
+    }
 
     public static int Main() => Execute<Build>(x => x.Publish);
 
@@ -77,5 +114,36 @@ class Build : NukeBuild
             .Output
             .Any(line => line.Text.Contains("wasm-tools"));
         return result;
+    }
+
+    Options Options()
+    {
+        IEnumerable<AdditionalCategory> additionalCategories = [];
+
+        return new Options
+        {
+            MainCategory = MainCategory.Development,
+            AdditionalCategories = Maybe.From(additionalCategories),
+            Name = "Zafiro.Avalonia Toolkit Catalog",
+            Version = GitVersion.MajorMinorPatch,
+            Comment = "Catalog of controls and other utilities in Zafiro.Avalonia",
+            Id = "com.SuperJMN.Zafiro.Avalonia",
+            StartupWmClass = "Zafiro.Avalonia",
+            HomePage = new Uri("https://github.com/SuperJMN-Zafiro/Zafiro.Avalonia"),
+            Keywords = new List<string>
+            {
+                "Toolkit",
+                "Avalonia",
+                "UI",
+                "UI Framework",
+                "Cross-platform",
+                "Multiplatform",
+                "Productivity",
+                "Library",
+            },
+            License = "MIT",
+            //ScreenshotUrls = Maybe.From(screenShots),
+            Summary = "Shows a catalog of controls and other utilities in Zafiro.Avalonia",
+        };
     }
 }

--- a/build/Configuration.cs
+++ b/build/Configuration.cs
@@ -1,0 +1,14 @@
+using System.ComponentModel;
+using Nuke.Common.Tooling;
+
+[TypeConverter(typeof(TypeConverter<Configuration>))]
+public class Configuration : Enumeration
+{
+    public static Configuration Debug = new Configuration { Value = nameof(Debug) };
+    public static Configuration Release = new Configuration { Value = nameof(Release) };
+
+    public static implicit operator string(Configuration configuration)
+    {
+        return configuration.Value;
+    }
+}

--- a/build/_build.csproj
+++ b/build/_build.csproj
@@ -14,6 +14,7 @@
   <ItemGroup>
       <PackageReference Include="Nuke.Common"/>
       <PackageReference Include="Zafiro.Deployment"/>
+    <PackageReference Include="Zafiro.Nuke"/>
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
- Added `PublishGitHubRelease` target with support for Linux, Windows, and Android deployments.
- Introduced `Configuration.cs` for build configuration management with Debug/Release modes.
- Enhanced Android deployment with signing options for Base64-encoded keystore support.
- Updated Zafiro and related package dependencies to align with latest versions.
- Added `Zafiro.Nuke` dependency to streamline Nuke build actions.