### PR TITLE
Merge headers in SlimWizard dialogs

### DIFF
--- a/src/Zafiro.Avalonia.Dialogs/Views/DialogControl.axaml
+++ b/src/Zafiro.Avalonia.Dialogs/Views/DialogControl.axaml
@@ -3,7 +3,9 @@
         xmlns:c="clr-namespace:Zafiro.Avalonia.Dialogs.Views"
         xmlns:generic="clr-namespace:System.Collections.Generic;assembly=System.Collections"
         xmlns:dialogs="clr-namespace:Zafiro.Avalonia.Dialogs"
-        xmlns:classic="clr-namespace:Zafiro.Avalonia.Controls.Wizards.Classic;assembly=Zafiro.Avalonia">
+        xmlns:classic="clr-namespace:Zafiro.Avalonia.Controls.Wizards.Classic;assembly=Zafiro.Avalonia"
+        xmlns:slim="clr-namespace:Zafiro.Avalonia.Controls.Wizards.Slim;assembly=Zafiro.Avalonia"
+        xmlns:converters="clr-namespace:Zafiro.Avalonia.Converters">
 
 
     <Styles.Resources>
@@ -60,6 +62,9 @@
                                     </Interaction.Behaviors>
                                 </Button>
                             </DataTemplate>
+                            <DataTemplate DataType="slim:ISlimWizard">
+                                <slim:SlimWizardControl Wizard="{Binding}" Header="{Binding $parent[c:DialogControl].Title}" />
+                            </DataTemplate>
                         </Border.DataTemplates>
 
                         <Border.Styles>
@@ -85,7 +90,17 @@
                             <TextBlock Grid.Row="0"
                                        FontWeight="Bold"
                                        Margin="0 0 0 10"
-                                       Text="{Binding $parent[c:DialogControl].Title}" IsVisible="{Binding $self.Text, Converter={x:Static ObjectConverters.IsNotNull}}" />
+                                       Text="{Binding $parent[c:DialogControl].Title}" IsVisible="{Binding $self.Text, Converter={x:Static ObjectConverters.IsNotNull}}">
+                                <TextBlock.Styles>
+                                    <Style>
+                                        <Style.Triggers>
+                                            <DataTrigger Binding="{Binding $parent[c:DialogControl].Content, Converter={x:Static converters:DialogConverters.IsSlimWizardControl}}" Value="True">
+                                                <Setter Property="IsVisible" Value="False" />
+                                            </DataTrigger>
+                                        </Style.Triggers>
+                                    </Style>
+                                </TextBlock.Styles>
+                            </TextBlock>
 
                             <!-- Content -->
                             <ScrollViewer Grid.Row="1" x:Name="DialogScrollViewer">

--- a/src/Zafiro.Avalonia/Controls/Wizards/Slim/SlimWizardControl.axaml
+++ b/src/Zafiro.Avalonia/Controls/Wizards/Slim/SlimWizardControl.axaml
@@ -16,6 +16,9 @@
         <Setter Property="Template">
             <ControlTemplate>
                 <DockPanel>
+                    <ContentPresenter DockPanel.Dock="Top"
+                                      Content="{TemplateBinding Header}"
+                                      IsVisible="{Binding $parent[slim:SlimWizardControl].Header, Converter={x:Static ObjectConverters.IsNotNull}}" />
                     <c:TrueCenterPanel DockPanel.Dock="Top">
                         <Button Theme="{StaticResource TransparentButton}"
                                 c:TrueCenterPanel.Dock="Left"

--- a/src/Zafiro.Avalonia/Controls/Wizards/Slim/SlimWizardControl.axaml.cs
+++ b/src/Zafiro.Avalonia/Controls/Wizards/Slim/SlimWizardControl.axaml.cs
@@ -8,9 +8,18 @@ public class SlimWizardControl : TemplatedControl
     public static readonly StyledProperty<ISlimWizard> WizardProperty = AvaloniaProperty.Register<SlimWizardControl, ISlimWizard>(
         nameof(Wizard));
 
+    public static readonly StyledProperty<object?> HeaderProperty = AvaloniaProperty.Register<SlimWizardControl, object?>(
+        nameof(Header));
+
     public ISlimWizard Wizard
     {
         get => GetValue(WizardProperty);
         set => SetValue(WizardProperty, value);
+    }
+
+    public object? Header
+    {
+        get => GetValue(HeaderProperty);
+        set => SetValue(HeaderProperty, value);
     }
 }

--- a/src/Zafiro.Avalonia/Converters/DialogConverters.cs
+++ b/src/Zafiro.Avalonia/Converters/DialogConverters.cs
@@ -1,0 +1,9 @@
+using Avalonia.Data.Converters;
+using Zafiro.Avalonia.Controls.Wizards.Slim;
+
+namespace Zafiro.Avalonia.Converters;
+
+public static class DialogConverters
+{
+    public static readonly FuncValueConverter<object?, bool> IsSlimWizardControl = new(obj => obj is SlimWizardControl);
+}


### PR DESCRIPTION
## Summary
- allow SlimWizardControl to display external header content
- add converter to detect SlimWizardControl
- use custom template for ISlimWizard in DialogControl
- hide dialog title when hosting a SlimWizardControl

## Testing
- `dotnet test` *(failed: missing Android workload)*

------
https://chatgpt.com/codex/tasks/task_e_688a283d7214832fb970b9b3543ba389