### PR TITLE
Add ReactiveIconButton control

### DIFF
--- a/samples/TestApp/TestApp/Samples/DataAnalysis/Heatmaps/HeatmapWithDendrogramsViewModel.cs
+++ b/samples/TestApp/TestApp/Samples/DataAnalysis/Heatmaps/HeatmapWithDendrogramsViewModel.cs
@@ -6,7 +6,7 @@ using Zafiro.UI.Shell.Utils;
 
 namespace TestApp.Samples.DataAnalysis.Heatmaps;
 
-[Section(icon: "mdi-data-matrix", sortIndex: 7)]
+[Section(icon: "mdi-data-matrix", sortIndex: 17)]
 public class HeatmapWithDendrogramsViewModel
 {
     public HeatmapWithDendrogramsViewModel()

--- a/samples/TestApp/TestApp/Samples/Drag/DragViewModel.cs
+++ b/samples/TestApp/TestApp/Samples/Drag/DragViewModel.cs
@@ -9,7 +9,7 @@ using Zafiro.UI.Shell.Utils;
 
 namespace TestApp.Samples.Drag;
 
-[Section(icon: "mdi-cursor-pointer", sortIndex: 8)]
+[Section(icon: "mdi-cursor-pointer", sortIndex: 18)]
 public partial class DragViewModel : ReactiveObject
 {
     [Reactive] private bool isEnabled;

--- a/samples/TestApp/TestApp/Samples/ReactiveButton/ReactiveButtonView.axaml
+++ b/samples/TestApp/TestApp/Samples/ReactiveButton/ReactiveButtonView.axaml
@@ -9,7 +9,7 @@
         <CommandViewModel />
     </UserControl.DataContext>
 
-    <Card Subheader="Buttons that known when they are busy">
+    <Card Subheader="Buttons that know when they are busy">
         <StackPanel Width="400" VerticalAlignment="Center">
             <ReactiveButton Content="This is where I heal my hurt" Command="{Binding NeverEndingCommand}" />
             <ReactiveButton HorizontalContentAlignment="Center" HorizontalAlignment="Stretch" Content="This is where I heal my hurt" Command="{Binding NeverEndingCommand}" />

--- a/samples/TestApp/TestApp/Samples/ReactiveButton/ReactiveButtonViewModel.cs
+++ b/samples/TestApp/TestApp/Samples/ReactiveButton/ReactiveButtonViewModel.cs
@@ -2,5 +2,5 @@ using Zafiro.UI.Shell.Utils;
 
 namespace TestApp.Samples.ReactiveButton;
 
-[Section(icon: "mdi-card-outline", name: "Reactive Button", sortIndex: 7)]
+[Section(icon: "mdi-button-cursor", name: "Reactive Button", sortIndex: 7)]
 public class ReactiveButtonViewModel;

--- a/samples/TestApp/TestApp/Samples/ReactiveIconButton/ReactiveIconButtonView.axaml
+++ b/samples/TestApp/TestApp/Samples/ReactiveIconButton/ReactiveIconButtonView.axaml
@@ -1,0 +1,27 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:ui="clr-namespace:Zafiro.UI;assembly=Zafiro.UI"
+             mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
+             x:Class="TestApp.Samples.ReactiveIconButton.ReactiveIconButtonView" x:DataType="CommandViewModel">
+
+    <UserControl.DataContext>
+        <CommandViewModel />
+    </UserControl.DataContext>
+
+    <Card Subheader="Buttons with icons that know when they are busy">
+        <StackPanel Width="400" VerticalAlignment="Center" Spacing="8">
+            <ReactiveIconButton Command="{Binding NeverEndingCommand}" Content="Working">
+                <ReactiveIconButton.Icon>
+                    <ui:Icon Source="fa-sync" />
+                </ReactiveIconButton.Icon>
+            </ReactiveIconButton>
+            <ReactiveIconButton Command="{Binding RegularCommand}" Content="Done">
+                <ReactiveIconButton.Icon>
+                    <ui:Icon Source="fa-check" />
+                </ReactiveIconButton.Icon>
+            </ReactiveIconButton>
+        </StackPanel>
+    </Card>
+</UserControl>

--- a/samples/TestApp/TestApp/Samples/ReactiveIconButton/ReactiveIconButtonView.axaml.cs
+++ b/samples/TestApp/TestApp/Samples/ReactiveIconButton/ReactiveIconButtonView.axaml.cs
@@ -1,0 +1,11 @@
+using Avalonia.Controls;
+
+namespace TestApp.Samples.ReactiveIconButton;
+
+public partial class ReactiveIconButtonView : UserControl
+{
+    public ReactiveIconButtonView()
+    {
+        InitializeComponent();
+    }
+}

--- a/samples/TestApp/TestApp/Samples/ReactiveIconButton/ReactiveIconButtonViewModel.cs
+++ b/samples/TestApp/TestApp/Samples/ReactiveIconButton/ReactiveIconButtonViewModel.cs
@@ -2,5 +2,5 @@ using Zafiro.UI.Shell.Utils;
 
 namespace TestApp.Samples.ReactiveIconButton;
 
-[Section(icon: "mdi-card-outline", name: "Reactive Icon Button", sortIndex: 8)]
+[Section(icon: "mdi-button-cursor", name: "Reactive Icon Button", sortIndex: 8)]
 public class ReactiveIconButtonViewModel;

--- a/samples/TestApp/TestApp/Samples/ReactiveIconButton/ReactiveIconButtonViewModel.cs
+++ b/samples/TestApp/TestApp/Samples/ReactiveIconButton/ReactiveIconButtonViewModel.cs
@@ -1,0 +1,6 @@
+using Zafiro.UI.Shell.Utils;
+
+namespace TestApp.Samples.ReactiveIconButton;
+
+[Section(icon: "mdi-card-outline", name: "Reactive Icon Button", sortIndex: 8)]
+public class ReactiveIconButtonViewModel;

--- a/src/Zafiro.Avalonia/Controls/ReactiveIconButton.axaml
+++ b/src/Zafiro.Avalonia/Controls/ReactiveIconButton.axaml
@@ -1,0 +1,56 @@
+<Styles xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:controls="clr-namespace:Zafiro.Avalonia.Controls"
+        xmlns:c="clr-namespace:FluentAvalonia.UI.Controls;assembly=FluentAvalonia">
+
+    <Design.PreviewWith>
+        <controls:ReactiveIconButton Content="Click">
+            <controls:ReactiveIconButton.Icon>
+                ICON
+            </controls:ReactiveIconButton.Icon>
+        </controls:ReactiveIconButton>
+    </Design.PreviewWith>
+
+    <Styles.Resources>
+        <ControlTheme x:Key="{x:Type controls:ReactiveIconButton}" TargetType="controls:ReactiveIconButton">
+            <Setter Property="Padding" Value="{DynamicResource ButtonPadding}" />
+            <Setter Property="HorizontalAlignment" Value="Left" />
+            <Setter Property="ButtonTheme">
+                <Setter.Value>
+                    <ControlTheme TargetType="Button" BasedOn="{StaticResource {x:Type Button}}" />
+                </Setter.Value>
+            </Setter>
+            <Setter Property="Template">
+                <ControlTemplate>
+                    <Button Theme="{TemplateBinding ButtonTheme}"
+                            IsDefault="{TemplateBinding IsDefault}"
+                            IsCancel="{TemplateBinding IsCancel}"
+                            IsTabStop="{TemplateBinding IsTabStop}"
+                            HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
+                            HorizontalAlignment="{TemplateBinding HorizontalAlignment}"
+                            Command="{Binding $parent[controls:ReactiveIconButton].Command}">
+                        <Button.Content>
+                            <Grid ColumnDefinitions="25,Auto">
+                                <Viewbox Margin="0 0 8 0" StretchDirection="DownOnly">
+                                    <c:ProgressRing Foreground="{TemplateBinding Foreground}"
+                                                    IsVisible="{Binding $parent[controls:ReactiveIconButton].Command.IsExecuting^}" />
+                                </Viewbox>
+                                <StackPanel Grid.Column="1" Orientation="Horizontal" Spacing="8" VerticalAlignment="Center">
+                                    <ContentPresenter IsVisible="{Binding !!$parent[controls:ReactiveIconButton].Icon}"
+                                                      Content="{TemplateBinding Icon}" />
+                                    <ContentPresenter IsVisible="{Binding !!$parent[controls:ReactiveIconButton].Content}"
+                                                      Content="{Binding $parent[controls:ReactiveIconButton].Content}"
+                                                      VerticalAlignment="Center" />
+                                </StackPanel>
+                            </Grid>
+                        </Button.Content>
+                    </Button>
+                </ControlTemplate>
+            </Setter>
+            <Style Selector="^ /template/ Button:disabled ContentPresenter">
+                <Setter Property="Opacity" Value="0.5" />
+            </Style>
+        </ControlTheme>
+    </Styles.Resources>
+
+</Styles>

--- a/src/Zafiro.Avalonia/Controls/ReactiveIconButton.axaml
+++ b/src/Zafiro.Avalonia/Controls/ReactiveIconButton.axaml
@@ -30,19 +30,18 @@
                             HorizontalAlignment="{TemplateBinding HorizontalAlignment}"
                             Command="{Binding $parent[controls:ReactiveIconButton].Command}">
                         <Button.Content>
-                            <Grid ColumnDefinitions="25,Auto">
-                                <Viewbox Margin="0 0 8 0" StretchDirection="DownOnly">
+                            <StackPanel Orientation="Horizontal" Spacing="8">
+                                <Viewbox StretchDirection="DownOnly" Height="18">
                                     <c:ProgressRing Foreground="{TemplateBinding Foreground}"
                                                     IsVisible="{Binding $parent[controls:ReactiveIconButton].Command.IsExecuting^}" />
                                 </Viewbox>
-                                <StackPanel Grid.Column="1" Orientation="Horizontal" Spacing="8" VerticalAlignment="Center">
-                                    <ContentPresenter IsVisible="{Binding !!$parent[controls:ReactiveIconButton].Icon}"
-                                                      Content="{TemplateBinding Icon}" />
-                                    <ContentPresenter IsVisible="{Binding !!$parent[controls:ReactiveIconButton].Content}"
-                                                      Content="{Binding $parent[controls:ReactiveIconButton].Content}"
-                                                      VerticalAlignment="Center" />
-                                </StackPanel>
-                            </Grid>
+                                <ContentPresenter IsVisible="{Binding !!$parent[controls:ReactiveIconButton].Icon}"
+                                                  VerticalAlignment="Center"
+                                                  Content="{TemplateBinding Icon}" />
+                                <ContentPresenter IsVisible="{Binding !!$parent[controls:ReactiveIconButton].Content}"
+                                                  Content="{Binding $parent[controls:ReactiveIconButton].Content}"
+                                                  VerticalAlignment="Center" />
+                            </StackPanel>
                         </Button.Content>
                     </Button>
                 </ControlTemplate>

--- a/src/Zafiro.Avalonia/Controls/ReactiveIconButton.axaml.cs
+++ b/src/Zafiro.Avalonia/Controls/ReactiveIconButton.axaml.cs
@@ -1,0 +1,16 @@
+using Avalonia.Styling;
+
+namespace Zafiro.Avalonia.Controls;
+
+public class ReactiveIconButton : ReactiveButton
+{
+    public static readonly StyledProperty<object> IconProperty =
+        AvaloniaProperty.Register<ReactiveIconButton, object>(nameof(Icon));
+
+    public object Icon
+    {
+        get => GetValue(IconProperty);
+        set => SetValue(IconProperty, value);
+    }
+}
+

--- a/src/Zafiro.Avalonia/Controls/ReactiveIconButton.axaml.cs
+++ b/src/Zafiro.Avalonia/Controls/ReactiveIconButton.axaml.cs
@@ -1,5 +1,3 @@
-using Avalonia.Styling;
-
 namespace Zafiro.Avalonia.Controls;
 
 public class ReactiveIconButton : ReactiveButton
@@ -13,4 +11,3 @@ public class ReactiveIconButton : ReactiveButton
         set => SetValue(IconProperty, value);
     }
 }
-

--- a/src/Zafiro.Avalonia/Styles.axaml
+++ b/src/Zafiro.Avalonia/Styles.axaml
@@ -50,6 +50,7 @@
     <StyleInclude Source="Controls/IconButton.axaml" />
     <StyleInclude Source="Controls/Loading.axaml" />
     <StyleInclude Source="Controls/ReactiveButton.axaml" />
+    <StyleInclude Source="Controls/ReactiveIconButton.axaml" />
     <StyleInclude Source="Controls/Shell/ShellView.axaml" />
     <StyleInclude Source="Controls/BulletList.axaml" />
     <StyleInclude Source="Controls/Shell/Sidebar.axaml" />


### PR DESCRIPTION
## Summary
- combine ReactiveButton and IconButton into ReactiveIconButton control
- show sample usage of ReactiveIconButton

## Testing
- `dotnet test test/Zafiro.Avalonia.Tests/Zafiro.Avalonia.Tests.csproj`
- `dotnet test test/Zafiro.Avalonia.Graphs.Tests/Zafiro.Avalonia.DataViz.Tests.csproj` *(fails: CS0234: namespace 'Graph' does not exist in 'Zafiro.Avalonia.DataViz')*


------
https://chatgpt.com/codex/tasks/task_e_6891cbcda46c832f8caea25cc547b668