### PR TITLE
Hide Cancel button on completion step for Slim wizards

### DIFF
--- a/src/Zafiro.Avalonia/Controls/Wizards/Slim/WizardNavigator.axaml
+++ b/src/Zafiro.Avalonia/Controls/Wizards/Slim/WizardNavigator.axaml
@@ -1,6 +1,7 @@
 <Styles xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        xmlns:controls="using:Zafiro.Avalonia.Controls.Wizards.Slim">
+        xmlns:controls="using:Zafiro.Avalonia.Controls.Wizards.Slim"
+        xmlns:converters="using:Zafiro.Avalonia.Converters">
     <Design.PreviewWith>
         <controls:WizardNavigator Width="500">
             <WizardNavigator.Wizard>
@@ -16,7 +17,10 @@
                 <ControlTemplate>
                     <DockPanel VerticalSpacing="20" Margin="{TemplateBinding Padding}">
                         <Panel DockPanel.Dock="Bottom">
-                            <Button Content="Cancel" HorizontalAlignment="Left" Command="{TemplateBinding Cancel}" />
+                            <Button Content="Cancel"
+                                    HorizontalAlignment="Left"
+                                    Command="{TemplateBinding Cancel}"
+                                    IsVisible="{Binding $parent[WizardNavigator].Wizard.CurrentStep.Step.Kind, Converter={x:Static converters:SlimWizardConverters.CancelVisible}}" />
                             <Button Content="{Binding $parent[WizardNavigator].Wizard.Next.Text, TargetNullValue='Next'}"
                                     Command="{Binding $parent[WizardNavigator].Wizard.Next}"
                                     HorizontalAlignment="Right" />

--- a/src/Zafiro.Avalonia/Converters/SlimWizardConverters.cs
+++ b/src/Zafiro.Avalonia/Converters/SlimWizardConverters.cs
@@ -1,0 +1,10 @@
+using Avalonia.Data.Converters;
+using Zafiro.UI.Wizards.Slim;
+
+namespace Zafiro.Avalonia.Converters;
+
+public static class SlimWizardConverters
+{
+    public static FuncValueConverter<StepKind, bool> CancelVisible { get; } = new(kind => kind != StepKind.Completion);
+}
+


### PR DESCRIPTION
## Summary
- hide Cancel button when wizard shows completion step
- add converter for step kind visibility logic

## Testing
- `dotnet test libs/Zafiro/test/Zafiro.Tests/Zafiro.Tests.csproj` *(fails: Could not load type 'FluentAssertions.Execution.Execute')*

------
https://chatgpt.com/codex/tasks/task_e_68921fbf6988832f855411a40fe13cd3