### PR TITLE
Show Empty.Content in empty ItemsControl

### DIFF
--- a/src/Zafiro.Avalonia/Controls/Empty.axaml
+++ b/src/Zafiro.Avalonia/Controls/Empty.axaml
@@ -1,0 +1,33 @@
+<Styles xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:controls="clr-namespace:Zafiro.Avalonia.Controls"
+        x:CompileBindings="True">
+    <Style Selector="ItemsControl.empty">
+        <Setter Property="Template">
+            <ControlTemplate>
+                <Grid>
+                    <ItemsPresenter/>
+                    <ContentControl x:Name="PART_EmptyContent"
+                                    Content="{TemplateBinding controls:Empty.Content}"
+                                    HorizontalAlignment="Center"
+                                    VerticalAlignment="Center"
+                                    IsHitTestVisible="False"
+                                    IsVisible="False"
+                                    Opacity="0"/>
+                </Grid>
+            </ControlTemplate>
+        </Setter>
+    </Style>
+
+    <Style Selector="ItemsControl.empty /template/ ContentControl#PART_EmptyContent">
+        <Setter Property="IsVisible" Value="True"/>
+        <Setter Property="Transitions">
+            <Setter.Value>
+                <Transitions>
+                    <DoubleTransition Property="Opacity" Duration="0:0:0.2" Delay="0:0:0.5"/>
+                </Transitions>
+            </Setter.Value>
+        </Setter>
+        <Setter Property="Opacity" Value="1"/>
+    </Style>
+</Styles>

--- a/src/Zafiro.Avalonia/Controls/Empty.cs
+++ b/src/Zafiro.Avalonia/Controls/Empty.cs
@@ -1,8 +1,58 @@
-﻿namespace Zafiro.Avalonia.Controls;
+using System.Collections.Specialized;
+using System.Reactive;
+using System.Reactive.Linq;
+using Avalonia.Controls;
+using CSharpFunctionalExtensions;
+
+namespace Zafiro.Avalonia.Controls;
 
 public class Empty : AvaloniaObject
 {
-    public static readonly AttachedProperty<object> ContentProperty = AvaloniaProperty.RegisterAttached<Empty, Control, object>("Content");
+    const string EmptyClass = "empty";
+
+    public static readonly AttachedProperty<object> ContentProperty =
+        AvaloniaProperty.RegisterAttached<Empty, Control, object>("Content", "Nothing to show");
+
+    static readonly AttachedProperty<IDisposable?> SubscriptionProperty =
+        AvaloniaProperty.RegisterAttached<Empty, Control, IDisposable?>("Subscription");
+
+    static Empty()
+    {
+        ContentProperty.Changed.Subscribe(OnContentChanged);
+    }
+
+    static void OnContentChanged(AvaloniaPropertyChangedEventArgs<object?> change)
+    {
+        if (change.Sender is not ItemsControl itemsControl)
+        {
+            return;
+        }
+
+        Maybe<IDisposable>.From(itemsControl.GetValue(SubscriptionProperty)).Execute(d => d.Dispose());
+
+        var items = itemsControl.Items;
+        var observable = Observable
+            .FromEventPattern<NotifyCollectionChangedEventHandler, NotifyCollectionChangedEventArgs>(
+                h => items.CollectionChanged += h,
+                h => items.CollectionChanged -= h);
+
+        var subscription = observable.Subscribe(_ => Update(itemsControl));
+        itemsControl.SetValue(SubscriptionProperty, subscription);
+
+        Update(itemsControl);
+    }
+
+    static void Update(ItemsControl control)
+    {
+        if (control.Items.Count == 0)
+        {
+            control.Classes.Add(EmptyClass);
+        }
+        else
+        {
+            control.Classes.Remove(EmptyClass);
+        }
+    }
 
     public static void SetContent(Visual obj, object value) => obj.SetValue(ContentProperty, value);
     public static object GetContent(Visual obj) => obj.GetValue(ContentProperty);

--- a/src/Zafiro.Avalonia/Styles.axaml
+++ b/src/Zafiro.Avalonia/Styles.axaml
@@ -59,4 +59,5 @@
     <StyleInclude Source="Controls/OverlayBorder.axaml" />
     <StyleInclude Source="Controls/Shell/ActionBar.axaml" />
     <StyleInclude Source="Controls/CardGrid.axaml" />
+    <StyleInclude Source="Controls/Empty.axaml" />
 </Styles>

--- a/test/Zafiro.Avalonia.Tests/EmptyItemsControlTests.cs
+++ b/test/Zafiro.Avalonia.Tests/EmptyItemsControlTests.cs
@@ -1,0 +1,28 @@
+using Avalonia.Controls;
+using Zafiro.Avalonia.Controls;
+using Xunit;
+
+namespace Zafiro.Avalonia.Tests;
+
+public class EmptyItemsControlTests
+{
+    [Fact]
+    public void Items_control_gets_empty_class_when_no_items()
+    {
+        var itemsControl = new ItemsControl();
+        Empty.SetContent(itemsControl, "Nothing");
+
+        Assert.Contains("empty", itemsControl.Classes);
+    }
+
+    [Fact]
+    public void Items_control_removes_empty_class_when_item_added()
+    {
+        var itemsControl = new ItemsControl();
+        Empty.SetContent(itemsControl, "Nothing");
+
+        itemsControl.Items.Add("item");
+
+        Assert.DoesNotContain("empty", itemsControl.Classes);
+    }
+}


### PR DESCRIPTION
## Summary
- add reactive attached property to add `empty` class and default placeholder
- style ItemsControl with `empty` class to show `Empty.Content`
- fade in `Empty.Content` with delay to prevent initial flicker
- test class toggling for empty ItemsControl

## Testing
- `MSBUILDTERMINALLOGGER=false dotnet test test/Zafiro.Avalonia.Tests/Zafiro.Avalonia.Tests.csproj`
- `MSBUILDTERMINALLOGGER=false dotnet test test/Zafiro.Avalonia.Graphs.Tests/Zafiro.Avalonia.DataViz.Tests.csproj` *(fails: type or namespace name 'Graph' does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_6892320db90c832f8f15a84e09bbf23a