### PR TITLE
chore: update Zafiro to version 33.0.7

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,7 +3,7 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <CentralPackageTransitivePinningEnabled>false</CentralPackageTransitivePinningEnabled>
     <AvaloniaVersion>11.3.2</AvaloniaVersion>
-    <ZafiroVersion>33.0.6</ZafiroVersion>
+      <ZafiroVersion>33.0.7</ZafiroVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="Avalonia" Version="$(AvaloniaVersion)" />


### PR DESCRIPTION
 Reverts multiple subscriptions to section content that damaged client apps.