### PR TITLE
Fix LeftFlexHeaderCard header wrapping

### DIFF
--- a/samples/TestApp/TestApp/Samples/Card/CardView.axaml
+++ b/samples/TestApp/TestApp/Samples/Card/CardView.axaml
@@ -28,7 +28,13 @@
             </StackPanel>
         </Card>
         <Card Grid.Row="1" Grid.Column="1" VerticalAlignment="Center" Theme="{StaticResource LeftFlexHeaderCard}" Margin="10" HeaderStartContent="{Icon fa-wallet}"
-              Header="Left header" Subheader="Title with left header adfasdfasdfasfasasfddasfdaasdfffffff">
+              Header="Left header" Subheader="Title with left header very long for you to see it wrapping">
+            <Card.HeaderEndContent>
+                <BalancedWrapGrid VerticalAlignment="Center" HorizontalSpacing="8">
+                    <Button Content="Do something" Classes="Expand CenterContent" />
+                    <Button Content="Refresh" Classes="Expand CenterContent" />
+                </BalancedWrapGrid>
+            </Card.HeaderEndContent>
             <StackPanel Spacing="10">
                 <BulletList Header="It offers you special places to put your contents:">
                     <x:String>Header</x:String>

--- a/src/Zafiro.Avalonia/Controls/Card.axaml
+++ b/src/Zafiro.Avalonia/Controls/Card.axaml
@@ -145,7 +145,7 @@
                                           ColumnSpacing="{Binding $parent[Card].HeaderSpacing}"
                                           FlexBox.Grow="2"
                                           FlexBox.Shrink="1"
-                                          FlexBox.Basis="{x:Static FlexBasis.Content}">
+                                          FlexBox.Basis="{x:Static FlexBasis.Auto}">
 
                                         <ContentControl Grid.Column="0"
                                                         Content="{Binding $parent[Card].HeaderStartContent}"
@@ -171,7 +171,7 @@
                                         FlexBox.MarginLeftAuto="True"
                                         FlexBox.Grow="1"
                                         FlexBox.Shrink="0"
-                                        FlexBox.Basis="{x:Static FlexBasis.Content}"
+                                        FlexBox.Basis="{x:Static FlexBasis.Auto}"
                                         HorizontalAlignment="Stretch"
                                         IsVisible="{Binding $self.Content, Converter={x:Static ObjectConverters.IsNotNull}}"
                                         Content="{Binding $parent[Card].HeaderEndContent}"

--- a/src/Zafiro.Avalonia/Controls/Card.axaml
+++ b/src/Zafiro.Avalonia/Controls/Card.axaml
@@ -141,19 +141,19 @@
                                          Gap="{Binding $parent[Card].HeaderSpacing}">
 
                                     <!-- Grupo izquierdo: Inicio + Título como bloque indivisible -->
-                                    <FlexBox Direction="Row"
-                                             AlignItems="Center"
-                                             Gap="{Binding $parent[Card].HeaderSpacing}"
-                                             FlexBox.Grow="2"
-                                             FlexBox.Shrink="1"
-                                             FlexBox.Basis="{x:Static FlexBasis.Content}">
+                                    <Grid ColumnDefinitions="Auto,*"
+                                          ColumnSpacing="{Binding $parent[Card].HeaderSpacing}"
+                                          FlexBox.Grow="2"
+                                          FlexBox.Shrink="1"
+                                          FlexBox.Basis="{x:Static FlexBasis.Content}">
 
-                                        <ContentControl
-                                            Content="{Binding $parent[Card].HeaderStartContent}"
-                                            ContentTemplate="{Binding $parent[Card].HeaderStartContentTemplate}"
-                                            IsVisible="{Binding $self.Content, Converter={x:Static ObjectConverters.IsNotNull}}" />
+                                        <ContentControl Grid.Column="0"
+                                                        Content="{Binding $parent[Card].HeaderStartContent}"
+                                                        ContentTemplate="{Binding $parent[Card].HeaderStartContentTemplate}"
+                                                        IsVisible="{Binding $self.Content, Converter={x:Static ObjectConverters.IsNotNull}}" />
 
-                                        <StackPanel Spacing="{Binding $parent[Card].HeaderSubheaderSpacing}">
+                                        <StackPanel Grid.Column="1"
+                                                    Spacing="{Binding $parent[Card].HeaderSubheaderSpacing}">
                                             <ContentControl
                                                 Theme="{Binding $parent[Card].HeaderTheme}"
                                                 Content="{Binding $parent[Card].Header}"
@@ -164,7 +164,7 @@
                                                 IsVisible="{Binding $self.Content, Converter={x:Static ObjectConverters.IsNotNull}}"
                                                 ContentTemplate="{Binding $parent[Card].SubheaderTemplate}" />
                                         </StackPanel>
-                                    </FlexBox>
+                                    </Grid>
 
                                     <!-- Fin: empuja a la derecha; cuando wrappea, ocupa la línea completa -->
                                     <ContentControl


### PR DESCRIPTION
## Summary
- prevent HeaderStartContent from shrinking
- allow header text to wrap when space is constrained

## Testing
- `dotnet build src/Zafiro.Avalonia`
- `dotnet test test/Zafiro.Avalonia.Tests/Zafiro.Avalonia.Tests.csproj` *(fails: Assert.Contains() Failure: Item not found in collection)*
- `dotnet test test/Zafiro.Avalonia.Graphs.Tests/Zafiro.Avalonia.DataViz.Tests.csproj` *(fails: CS0234: The type or namespace name 'Graph' does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_68a72e1ec604832fa5f9de4e10866156