### PR TITLE
Add FlexBox header sample with wrapping buttons

### DIFF
--- a/samples/TestApp/TestApp/Samples/Panels/PanelsView.axaml
+++ b/samples/TestApp/TestApp/Samples/Panels/PanelsView.axaml
@@ -139,6 +139,22 @@
                 </FlexBox>
             </Card>
 
+            <Card Header="FlexBox header with wrapping buttons">
+                <FlexBox Wrap="Wrap" AlignItems="Center" RowGap="8" ColumnGap="8">
+                    <Border Width="32" Height="32" Background="Gray" />
+                    <TextBlock Text="Título largo de ejemplo" FlexBox.Grow="1" VerticalAlignment="Center" />
+                    <StackPanel Orientation="Horizontal"
+                                Spacing="4"
+                                FlexBox.MarginLeftAuto="True"
+                                FlexBox.Grow="1"
+                                FlexBox.Shrink="1"
+                                FlexBox.Basis="{x:Static FlexBasis.Content}">
+                        <Button Content="Acción 1" />
+                        <Button Content="Acción 2" />
+                    </StackPanel>
+                </FlexBox>
+            </Card>
+
             <Card Header="BoostrapGridPanel">
                 <BootstrapGridPanel MaxColumns="12" Gutter="16">
 


### PR DESCRIPTION
## Summary
- showcase FlexBox header that wraps action buttons on narrow widths

## Testing
- `dotnet build samples/TestApp/TestApp.Desktop/TestApp.Desktop.csproj`
- `dotnet test` *(fails: System.ArgumentOutOfRangeException from TerminalLogger)*

------
https://chatgpt.com/codex/tasks/task_e_68a86ab7f13c832f9d3e6f8908fecadd