### PR TITLE
feat(packaging): include source generator in NuGet so Zafiro.Avalonia implicitly enables Generators

### DIFF
--- a/src/Zafiro.Avalonia/Zafiro.Avalonia.csproj
+++ b/src/Zafiro.Avalonia/Zafiro.Avalonia.csproj
@@ -30,6 +30,14 @@
         <ProjectReference Include="..\Zafiro.Avalonia.Generators\Zafiro.Avalonia.Generators.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
     </ItemGroup>
 
+    <!-- Ensure the source generator is packaged inside this NuGet under analyzers/dotnet/cs -->
+    <ItemGroup>
+        <None Include="..\Zafiro.Avalonia.Generators\bin\$(Configuration)\netstandard2.0\Zafiro.Avalonia.Generators.dll"
+              Pack="true"
+              PackagePath="analyzers/dotnet/cs"
+              Visible="false" />
+    </ItemGroup>
+
     <ItemGroup>
         <AdditionalFiles Include="**/*.axaml" />
     </ItemGroup>


### PR DESCRIPTION
This PR ensures the source generator runs for consumers by bundling the analyzer DLL inside the NuGet package.\n\nDetails\n- Pack the generator DLL under `analyzers/dotnet/cs`.\n- Keep the project-to-project Analyzer reference for local builds.\n\nOutcome\n- Installing Zafiro.Avalonia automatically activates Zafiro.Avalonia.Generators without requiring a separate package.\n\nNotes\n- The Generators project remains non-packable (IsPackable=false).\n- No API surface changes; packaging-only change.