### PR TITLE
Ensure DataTypeViewLocator registers Dialogs views

### DIFF
--- a/src/Zafiro.Avalonia.Dialogs/Zafiro.Avalonia.Dialogs.csproj
+++ b/src/Zafiro.Avalonia.Dialogs/Zafiro.Avalonia.Dialogs.csproj
@@ -17,5 +17,11 @@
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="..\Zafiro.Avalonia\Zafiro.Avalonia.csproj"/>
+        <!-- Add the source generator as an analyzer so DataTypeViewLocator registrations run -->
+        <ProjectReference Include="..\Zafiro.Avalonia.Generators\Zafiro.Avalonia.Generators.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
+    </ItemGroup>
+    <!-- Make .axaml files visible to the generator -->
+    <ItemGroup>
+        <AdditionalFiles Include="**/*.axaml" />
     </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary
- include DataTypeViewLocator source generator in Zafiro.Avalonia.Dialogs project
- expose .axaml files so views from Dialogs are globally registered

## Testing
- `dotnet build src/Zafiro.Avalonia.Dialogs/Zafiro.Avalonia.Dialogs.csproj`

------
https://chatgpt.com/codex/tasks/task_e_68baf33359b4832fae708d97ade1fcdf