### PR TITLE
ResponsivePresenter: fix override and add sample (SlimDataGrid wide, ItemsControl narrow)

### DIFF
--- a/samples/TestApp/TestApp/Samples/Layout/ResponsivePresenter/ResponsivePresenterView.axaml
+++ b/samples/TestApp/TestApp/Samples/Layout/ResponsivePresenter/ResponsivePresenterView.axaml
@@ -1,0 +1,79 @@
+﻿<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:c="clr-namespace:Zafiro.Avalonia.Controls;assembly=Zafiro.Avalonia"
+             xmlns:rp="clr-namespace:TestApp.Samples.Layout.ResponsivePresenterSample"
+             xmlns:misc="clr-namespace:Zafiro.Avalonia.Misc;assembly=Zafiro.Avalonia"
+             mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
+             x:Class="TestApp.Samples.Layout.ResponsivePresenterSample.ResponsivePresenterView"
+             x:DataType="rp:ResponsivePresenterViewModel">
+
+    <Design.DataContext>
+        <rp:ResponsivePresenterViewModel />
+    </Design.DataContext>
+
+    <UserControl.Styles>
+        <StyleInclude Source="/Samples/SampleStyles.axaml" />
+    </UserControl.Styles>
+
+    <UserControl.Resources>
+        <DataTemplate x:Key="NameTemplate">
+            <TextBlock Foreground="#283337" x:DataType="x:String" Text="{Binding }" VerticalAlignment="Center" />
+        </DataTemplate>
+        <DataTemplate x:Key="SurnameTemplate">
+            <TextBlock TextAlignment="Center" Foreground="#536A72" x:DataType="x:String" Text="{Binding }" VerticalAlignment="Center" />
+        </DataTemplate>
+    </UserControl.Resources>
+
+    <c:HeaderedContainer Header="ResponsivePresenter demo: SlimDataGrid (wide) vs ItemsControl (narrow)">
+        <c:ResponsivePresenter Breakpoint="600">
+            <c:ResponsivePresenter.Narrow>
+                <Border Padding="10">
+                    <ItemsControl ItemsSource="{Binding People}">
+                        <ItemsControl.ItemTemplate>
+                            <DataTemplate>
+                                <Border Padding="8" Margin="0,0,0,8" CornerRadius="6" BorderBrush="#33000000" Background="#0A000000" BorderThickness="1">
+                                    <StackPanel Spacing="2">
+                                        <TextBlock Text="Nombre:" FontWeight="SemiBold" />
+                                        <TextBlock Text="{Binding Name}" />
+                                        <TextBlock Margin="0,4,0,0" Text="Apellidos:" FontWeight="SemiBold" />
+                                        <TextBlock Text="{Binding Surname}" />
+                                    </StackPanel>
+                                </Border>
+                            </DataTemplate>
+                        </ItemsControl.ItemTemplate>
+                    </ItemsControl>
+                </Border>
+            </c:ResponsivePresenter.Narrow>
+            <c:ResponsivePresenter.Wide>
+                <SlimDataGrid ItemsSource="{Binding People}" HeaderPadding="10" Padding="10">
+                    <SlimDataGrid.Columns>
+                        <Column Header="Name" Binding="{Binding Name}" CellTemplate="{StaticResource NameTemplate}" />
+                        <Column Header="Surname" Binding="{Binding Surname}" CellTemplate="{StaticResource SurnameTemplate}">
+                            <Column.HeaderTemplate>
+                                <DataTemplate DataType="x:String">
+                                    <TextBlock HorizontalAlignment="Center" Text="{Binding}" />
+                                </DataTemplate>
+                            </Column.HeaderTemplate>
+                        </Column>
+                        <Column Header="Link">
+                            <Column.HeaderTemplate>
+                                <DataTemplate DataType="x:String">
+                                    <TextBlock HorizontalAlignment="Center" Text="{Binding}" />
+                                </DataTemplate>
+                            </Column.HeaderTemplate>
+                            <Column.CellTemplate>
+                                <DataTemplate>
+                                    <Button HorizontalAlignment="Center" Content="Open" CommandParameter="http://www.youtube.com"
+                                            Command="{Binding Source={x:Static misc:Commands.Instance}, Path=LaunchUri}" />
+                                </DataTemplate>
+                            </Column.CellTemplate>
+                        </Column>
+                    </SlimDataGrid.Columns>
+                </SlimDataGrid>
+            </c:ResponsivePresenter.Wide>
+        </c:ResponsivePresenter>
+    </c:HeaderedContainer>
+</UserControl>
+

--- a/samples/TestApp/TestApp/Samples/Layout/ResponsivePresenter/ResponsivePresenterView.axaml.cs
+++ b/samples/TestApp/TestApp/Samples/Layout/ResponsivePresenter/ResponsivePresenterView.axaml.cs
@@ -1,0 +1,12 @@
+﻿using Avalonia.Controls;
+
+namespace TestApp.Samples.Layout.ResponsivePresenterSample;
+
+public partial class ResponsivePresenterView : UserControl
+{
+    public ResponsivePresenterView()
+    {
+        InitializeComponent();
+    }
+}
+

--- a/samples/TestApp/TestApp/Samples/Layout/ResponsivePresenter/ResponsivePresenterViewModel.cs
+++ b/samples/TestApp/TestApp/Samples/Layout/ResponsivePresenter/ResponsivePresenterViewModel.cs
@@ -1,0 +1,25 @@
+﻿using System.Collections.ObjectModel;
+using ReactiveUI;
+using ReactiveUI.SourceGenerators;
+using TestApp.Samples.SlimDataGrid;
+using Zafiro.UI.Shell.Utils;
+
+namespace TestApp.Samples.Layout.ResponsivePresenterSample;
+
+[Section(icon: "mdi-tablet-cellphone", sortIndex: 10)]
+public partial class ResponsivePresenterViewModel : ReactiveObject
+{
+    public ResponsivePresenterViewModel()
+    {
+        People = new ReadOnlyObservableCollection<Person>(new ObservableCollection<Person>([
+            new() { Name = "Pepe", Surname = "Marchena" },
+            new() { Name = "Carlos", Surname = "Santana" },
+            new() { Name = "Lola", Surname = "Flores" },
+            new() { Name = "Rafael", Surname = "Amargo" },
+            new() { Name = "Juanito", Surname = "Valderrama" }
+        ]));
+    }
+
+    public ReadOnlyObservableCollection<Person> People { get; }
+}
+

--- a/src/Zafiro.Avalonia/Controls/ResponsivePresenter.cs
+++ b/src/Zafiro.Avalonia/Controls/ResponsivePresenter.cs
@@ -1,0 +1,86 @@
+namespace Zafiro.Avalonia.Controls;
+
+using System;
+
+// Simple, self-measuring presenter: swaps content when its *own* width crosses a breakpoint.
+public class ResponsivePresenter : ContentControl
+{
+    public static readonly StyledProperty<Control?> NarrowProperty =
+        AvaloniaProperty.Register<ResponsivePresenter, Control?>(nameof(Narrow));
+
+    public static readonly StyledProperty<Control?> WideProperty =
+        AvaloniaProperty.Register<ResponsivePresenter, Control?>(nameof(Wide));
+
+    public static readonly StyledProperty<double> BreakpointProperty =
+        AvaloniaProperty.Register<ResponsivePresenter, double>(nameof(Breakpoint), 900);
+
+    private IDisposable? _boundsSub;
+    private bool? _isWide; // null = unknown, prevents redundant Content sets
+
+    public Control? Narrow
+    {
+        get => GetValue(NarrowProperty);
+        set => SetValue(NarrowProperty, value);
+    }
+
+    public Control? Wide
+    {
+        get => GetValue(WideProperty);
+        set => SetValue(WideProperty, value);
+    }
+
+    public double Breakpoint
+    {
+        get => GetValue(BreakpointProperty);
+        set => SetValue(BreakpointProperty, value);
+    }
+
+    protected override void OnAttachedToVisualTree(VisualTreeAttachmentEventArgs e)
+    {
+        base.OnAttachedToVisualTree(e);
+        _boundsSub = this.GetObservable(BoundsProperty).Subscribe(_ => UpdateContentIfNeeded());
+        UpdateContentIfNeeded();
+    }
+
+    protected override void OnDetachedFromVisualTree(VisualTreeAttachmentEventArgs e)
+    {
+        base.OnDetachedFromVisualTree(e);
+        _boundsSub?.Dispose();
+        _boundsSub = null;
+        _isWide = null;
+    }
+
+    // Avalonia 11 overrides the non-generic OnPropertyChanged
+    protected override void OnPropertyChanged(AvaloniaPropertyChangedEventArgs change)
+    {
+        base.OnPropertyChanged(change);
+
+        // If templates or breakpoint change, reevaluate immediately.
+        if (change.Property == BreakpointProperty ||
+            change.Property == NarrowProperty ||
+            change.Property == WideProperty)
+        {
+            UpdateContentIfNeeded(force: true);
+        }
+    }
+
+    private void UpdateContentIfNeeded(bool force = false)
+    {
+        var width = Bounds.Width;
+        if (width <= 0)
+            return; // Not arranged yet; skip spurious passes.
+
+        var nowWide = width >= Breakpoint;
+
+        // Avoid reassigning Content unless the "mode" actually changes or caller forces it.
+        if (!force && _isWide == nowWide)
+            return;
+
+        _isWide = nowWide;
+
+        // Only one subtree is in the visual tree at a time.
+        var desired = nowWide ? Wide ?? Narrow : Narrow ?? Wide;
+        if (!ReferenceEquals(Content, desired))
+            Content = desired;
+    }
+}


### PR DESCRIPTION
This PR fixes ResponsivePresenter for Avalonia 11 and adds a sample to TestApp.\n\nChanges:\n- Fix ResponsivePresenter override signature: use non-generic OnPropertyChanged(AvaloniaPropertyChangedEventArgs).\n- Add ResponsivePresenter sample in TestApp:\n  - Wide view uses SlimDataGrid.\n  - Narrow view uses a compact linear ItemsControl with bordered items.\n- Minor styling for narrow template (labels + spacing).\n\nWhy:\n- Ensure correct behavior on Avalonia 11 and provide a concrete example for responsive UI.\n\nNotes:\n- Breakpoint is set to 600px; feel free to tweak.\n