### PR TITLE
ResponsivePresenter: strict template-based control (no public Content)

### DIFF
--- a/src/Zafiro.Avalonia/Controls/ResponsivePresenter.axaml
+++ b/src/Zafiro.Avalonia/Controls/ResponsivePresenter.axaml
@@ -1,0 +1,26 @@
+<Styles xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:controls="clr-namespace:Zafiro.Avalonia.Controls;assembly=Zafiro.Avalonia">
+
+  <Styles.Resources>
+    <ControlTheme x:Key="{x:Type controls:ResponsivePresenter}" TargetType="controls:ResponsivePresenter">
+      <Setter Property="Template">
+        <ControlTemplate>
+          <ContentPresenter x:Name="PART_Presenter"/>
+        </ControlTemplate>
+      </Setter>
+    </ControlTheme>
+  </Styles.Resources>
+
+  <Design.PreviewWith>
+    <controls:ResponsivePresenter>
+      <controls:ResponsivePresenter.Narrow>
+        <Border Background="#1133AA" Padding="10"><TextBlock Text="Narrow"/></Border>
+      </controls:ResponsivePresenter.Narrow>
+      <controls:ResponsivePresenter.Wide>
+        <Border Background="#11AA33" Padding="10"><TextBlock Text="Wide"/></Border>
+      </controls:ResponsivePresenter.Wide>
+    </controls:ResponsivePresenter>
+  </Design.PreviewWith>
+</Styles>
+


### PR DESCRIPTION
This PR makes ResponsivePresenter a strict, template-based control.\n\nChanges:\n- Change base from ContentControl to TemplatedControl.\n- Render via internal ContentPresenter (PART_Presenter) defined in a new ResponsivePresenter.axaml theme.\n- Keep only Narrow and Wide as inputs; users cannot override Content anymore.\n- Maintain responsive behavior based on Bounds.Width and Breakpoint.\n\nWhy:\n- Prevent external content injection and enforce the intended API surface (Narrow/Wide only).\n\nNotes:\n- Existing usages that set Narrow/Wide continue to work.\n- If any consumer was setting Content directly, it must be updated to use Narrow/Wide instead.\n