### PR TITLE
Decouple Zafiro.Avalonia.Generators (explicit analyzer package)

### DIFF
--- a/WARP.md
+++ b/WARP.md
@@ -54,14 +54,67 @@ Implementation notes (TestApp.Android)
 Publishing (DotnetDeployer)
 
 - This repo prefers DotnetDeployer for packaging and releases (no NUKE)
-- Install tool (once): dotnet tool install --global DotnetDeployer.Tool
-- Set secrets as env vars in your shell (example)
-  - export NUGET_API_KEY={{NUGET_API_KEY}}
-- Dry-run (no push)
-  - dotnetdeployer nuget --api-key "$NUGET_API_KEY" --no-push
-- Real publish
-  - dotnetdeployer nuget --api-key "$NUGET_API_KEY"
-  - Optionally: dotnetdeployer release
+- Local usage
+  - Install tool (once): dotnet tool install --global DotnetDeployer.Tool
+  - Set secrets as env vars in your shell (example)
+    - export NUGET_API_KEY={{NUGET_API_KEY}}
+  - Dry-run (no push)
+    - dotnetdeployer nuget --api-key "$NUGET_API_KEY" --no-push
+  - Real publish
+    - dotnetdeployer nuget --api-key "$NUGET_API_KEY"
+    - Optionally: dotnetdeployer release
+
+Azure Pipelines (CI/CD)
+
+- Location: azure-pipelines.yml
+- Triggers: push to master, PRs to master or any branch
+- Agent: ubuntu-latest
+- Steps summary
+  - Full checkout with submodules (fetchDepth: 0)
+  - Install .NET 9 SDK (UseDotNet@2)
+  - Install Android workload (dotnet workload install android)
+    - Note: not strictly required for NuGet-only publishing, but kept for optional app release tasks
+  - Install DotnetDeployer.Tool globally and print version
+  - Package and publish with DotnetDeployer
+    - On master: dotnetdeployer nuget --api-key '$(NuGetApiKey)'
+    - On other branches: dotnetdeployer nuget --api-key '$(NuGetApiKey)' --no-push (dry run)
+- Secrets/variables
+  - Variable group: api-keys
+  - Variables used: NuGetApiKey (consumed by DotnetDeployer)
+- Optional (commented in YAML): release flow using dotnetdeployer release with GitHub token and Android signing inputs
+
+Source generators: Zafiro.Avalonia.Generators
+
+- What changed (rationale)
+  - Previously, the Zafiro.Avalonia package embedded and auto-wired the source generator as an Analyzer. This made the generator run implicitly when consuming Zafiro.Avalonia.
+  - Now the generator is decoupled and shipped as its own NuGet package (Zafiro.Avalonia.Generators). Consumers opt in explicitly.
+- Packaging
+  - src/Zafiro.Avalonia.Generators is IsPackable=true
+  - The analyzer assembly is included under analyzers/dotnet/cs in the .nupkg
+  - A buildTransitive props file (buildTransitive/Zafiro.Avalonia.Generators.props) exposes **/*.axaml as AdditionalFiles automatically in consuming projects
+- Consumption guidelines
+  - NuGet (recommended for consumers)
+    - Add a PackageReference with PrivateAssets=all and IncludeAssets including analyzers and buildTransitive:
+      ```xml path=null start=null
+      <ItemGroup>
+        <PackageReference Include="Zafiro.Avalonia.Generators">
+          <PrivateAssets>all</PrivateAssets>
+          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+      </ItemGroup>
+      ```
+  - Local development inside this repo
+    - Projects can reference the generator project as an Analyzer for fast iteration:
+      ```xml path=null start=null
+      <ItemGroup>
+        <ProjectReference Include="..\Zafiro.Avalonia.Generators\Zafiro.Avalonia.Generators.csproj"
+                          OutputItemType="Analyzer"
+                          ReferenceOutputAssembly="false" />
+      </ItemGroup>
+      ```
+    - The repo uses the UseLocalZafiroReferences switch to toggle between local ProjectReference (true) and NuGet PackageReference (false). This is already configured in Zafiro.Avalonia.Dialogs and samples/TestApp/TestApp.
+- Migration note
+  - Zafiro.Avalonia no longer includes the generator in its package and no longer references it as an Analyzer. Any project that requires the generated registrations must explicitly reference Zafiro.Avalonia.Generators as shown above.
 
 Submodule: libs/Zafiro
 

--- a/samples/TestApp/TestApp/TestApp.csproj
+++ b/samples/TestApp/TestApp/TestApp.csproj
@@ -33,7 +33,7 @@
         <ProjectReference Include="../../../src/Zafiro.Avalonia.DataViz/Zafiro.Avalonia.DataViz.csproj"/>
         <ProjectReference Include="../../../src/Zafiro.Avalonia.Dialogs/Zafiro.Avalonia.Dialogs.csproj"/>
         <ProjectReference Include="../../../src/Zafiro.Avalonia/Zafiro.Avalonia.csproj"/>
-        <!-- Add the source generator as an analyzer so it runs in this project -->
+        <!-- Run the source generator locally as an Analyzer during in-repo builds -->
         <ProjectReference Include="../../../src/Zafiro.Avalonia.Generators/Zafiro.Avalonia.Generators.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false"/>
     </ItemGroup>
 

--- a/src/Zafiro.Avalonia.Dialogs/Zafiro.Avalonia.Dialogs.csproj
+++ b/src/Zafiro.Avalonia.Dialogs/Zafiro.Avalonia.Dialogs.csproj
@@ -17,7 +17,7 @@
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="..\Zafiro.Avalonia\Zafiro.Avalonia.csproj"/>
-        <!-- Add the source generator as an analyzer so DataTypeViewLocator registrations run -->
+        <!-- Run the source generator locally as an Analyzer during in-repo builds and packing -->
         <ProjectReference Include="..\Zafiro.Avalonia.Generators\Zafiro.Avalonia.Generators.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
     </ItemGroup>
     <!-- Make .axaml files visible to the generator -->

--- a/src/Zafiro.Avalonia.Generators/Zafiro.Avalonia.Generators.csproj
+++ b/src/Zafiro.Avalonia.Generators/Zafiro.Avalonia.Generators.csproj
@@ -3,14 +3,20 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
-    <IsPackable>false</IsPackable>
+    <IsPackable>true</IsPackable>
     <IncludeBuildOutput>false</IncludeBuildOutput>
     <OutputItemType>Analyzer</OutputItemType>
   </PropertyGroup>
+  <Import Project="..\Common.props" />
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" PrivateAssets="all" />
   </ItemGroup>
     <PropertyGroup>
         <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
     </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="$(OutputPath)$(AssemblyName).dll" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
+    <None Include="buildTransitive/Zafiro.Avalonia.Generators.props" Pack="true" PackagePath="buildTransitive/Zafiro.Avalonia.Generators.props" />
+  </ItemGroup>
 </Project>

--- a/src/Zafiro.Avalonia.Generators/buildTransitive/Zafiro.Avalonia.Generators.props
+++ b/src/Zafiro.Avalonia.Generators/buildTransitive/Zafiro.Avalonia.Generators.props
@@ -1,0 +1,6 @@
+<Project>
+  <!-- Expose .axaml files to the generator in consuming projects -->
+  <ItemGroup>
+    <AdditionalFiles Include="**/*.axaml" />
+  </ItemGroup>
+</Project>

--- a/src/Zafiro.Avalonia/Zafiro.Avalonia.csproj
+++ b/src/Zafiro.Avalonia/Zafiro.Avalonia.csproj
@@ -26,17 +26,6 @@
         </PackageReference>
     </ItemGroup>
 
-    <ItemGroup>
-        <ProjectReference Include="..\Zafiro.Avalonia.Generators\Zafiro.Avalonia.Generators.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
-    </ItemGroup>
-
-    <!-- Ensure the source generator is packaged inside this NuGet under analyzers/dotnet/cs -->
-    <ItemGroup>
-        <None Include="..\Zafiro.Avalonia.Generators\bin\$(Configuration)\netstandard2.0\Zafiro.Avalonia.Generators.dll"
-              Pack="true"
-              PackagePath="analyzers/dotnet/cs"
-              Visible="false" />
-    </ItemGroup>
 
     <ItemGroup>
         <AdditionalFiles Include="**/*.axaml" />


### PR DESCRIPTION
This PR decouples the source generator from the main package and publishes it as a standalone analyzer package.\n\nSummary\n- Remove implicit generator hook from Zafiro.Avalonia (no analyzers bundled)\n- Make Zafiro.Avalonia.Generators IsPackable=true and include analyzer under analyzers/dotnet/cs\n- Add buildTransitive props to expose **/*.axaml as AdditionalFiles in consumers\n- Update Dialogs and TestApp to use Analyzer ProjectReference in-repo\n- Update WARP.md documenting CI flow with DotnetDeployer and generator usage\n\nRationale\n- Consumers opt-in explicitly to the generator via PackageReference\n- Keeps the main package lean and avoids implicit analyzer behavior\n\nCI\n- Azure Pipelines publishes via DotnetDeployer on master (dry-run on other branches).