### PR TITLE
DevOps: nuget.config + package READMEs + SourceLink/symbols

### DIFF
--- a/nuget.config
+++ b/nuget.config
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+  </packageSources>
+  <!-- Package source mapping silences NU1507 even if user-level config defines extra sources. -->
+  <packageSourceMapping>
+    <packageSource key="nuget.org">
+      <package pattern="*" />
+    </packageSource>
+  </packageSourceMapping>
+</configuration>

--- a/src/Common.props
+++ b/src/Common.props
@@ -22,4 +22,24 @@
 		<None Include="..\..\icon.png" Pack="true" PackagePath=""/>
 	</ItemGroup>
 
+	<!-- Package Readme: include repo README.md if present -->
+	<PropertyGroup>
+		<PackageReadmeFile Condition="Exists('..\\..\\README.md')">README.md</PackageReadmeFile>
+	</PropertyGroup>
+	<ItemGroup Condition="Exists('..\\..\\README.md')">
+		<None Include="..\..\README.md" Pack="true" PackagePath=""/>
+	</ItemGroup>
+
+	<!-- SourceLink + symbols for better debugging from NuGet -->
+	<PropertyGroup>
+		<PublishRepositoryUrl>true</PublishRepositoryUrl>
+		<EmbedUntrackedSources>true</EmbedUntrackedSources>
+		<IncludeSymbols>true</IncludeSymbols>
+		<SymbolPackageFormat>snupkg</SymbolPackageFormat>
+		<ContinuousIntegrationBuild Condition=" '$(ContinuousIntegrationBuild)' == '' ">true</ContinuousIntegrationBuild>
+	</PropertyGroup>
+	<ItemGroup>
+		<PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All" Version="8.0.0" />
+	</ItemGroup>
+
 </Project>

--- a/src/Zafiro.Avalonia.DataViz/README.md
+++ b/src/Zafiro.Avalonia.DataViz/README.md
@@ -1,0 +1,10 @@
+# Zafiro.Avalonia.DataViz
+
+Data visualization controls for Avalonia.
+
+Highlights:
+- Heatmaps with dendrograms, gradient controls, and other chart helpers
+- Integrates with Zafiro.Avalonia components
+
+Getting started:
+- dotnet add package Zafiro.Avalonia.DataViz

--- a/src/Zafiro.Avalonia.DataViz/Zafiro.Avalonia.DataViz.csproj
+++ b/src/Zafiro.Avalonia.DataViz/Zafiro.Avalonia.DataViz.csproj
@@ -8,6 +8,7 @@
 
     <ItemGroup>
         <AvaloniaResource Include="Assets\**" />
+        <None Include="README.md" Pack="true" PackagePath="" Condition="Exists('README.md')" />
     </ItemGroup>
 
     <Import Project="..\Common.props" />

--- a/src/Zafiro.Avalonia.Dialogs/README.md
+++ b/src/Zafiro.Avalonia.Dialogs/README.md
@@ -1,0 +1,12 @@
+# Zafiro.Avalonia.Dialogs
+
+Dialogs and helpers for building user interactions on top of Zafiro.Avalonia.
+
+Highlights:
+- Reactive dialogs, notifications and helpers
+- Works with Zafiro UI primitives
+- Supports generator-based registrations via Zafiro.Avalonia.Generators
+
+Getting started:
+- dotnet add package Zafiro.Avalonia.Dialogs
+- Optionally add Zafiro.Avalonia.Generators to enable auto-registrations

--- a/src/Zafiro.Avalonia.Dialogs/Zafiro.Avalonia.Dialogs.csproj
+++ b/src/Zafiro.Avalonia.Dialogs/Zafiro.Avalonia.Dialogs.csproj
@@ -20,8 +20,9 @@
         <!-- Run the source generator locally as an Analyzer during in-repo builds and packing -->
         <ProjectReference Include="..\Zafiro.Avalonia.Generators\Zafiro.Avalonia.Generators.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
     </ItemGroup>
-    <!-- Make .axaml files visible to the generator -->
+    <!-- Make .axaml files visible to the generator and pack README -->
     <ItemGroup>
         <AdditionalFiles Include="**/*.axaml" />
+        <None Include="README.md" Pack="true" PackagePath="" Condition="Exists('README.md')" />
     </ItemGroup>
 </Project>

--- a/src/Zafiro.Avalonia.Generators/README.md
+++ b/src/Zafiro.Avalonia.Generators/README.md
@@ -1,0 +1,14 @@
+# Zafiro.Avalonia.Generators
+
+Source generator for the Zafiro.Avalonia ecosystem.
+
+What it does:
+- Registers ViewModel-View pairs by naming convention and x:DataType discovery
+- Emits DI registration helpers for section navigation
+
+How to use (NuGet):
+- dotnet add package Zafiro.Avalonia.Generators
+- The package includes a buildTransitive props that exposes **/*.axaml as AdditionalFiles automatically.
+
+How to use (local dev in this repo):
+- Add a ProjectReference to src/Zafiro.Avalonia.Generators with OutputItemType="Analyzer" and ReferenceOutputAssembly="false".

--- a/src/Zafiro.Avalonia.Generators/Zafiro.Avalonia.Generators.csproj
+++ b/src/Zafiro.Avalonia.Generators/Zafiro.Avalonia.Generators.csproj
@@ -18,5 +18,6 @@
   <ItemGroup>
     <None Include="$(OutputPath)$(AssemblyName).dll" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
     <None Include="buildTransitive/Zafiro.Avalonia.Generators.props" Pack="true" PackagePath="buildTransitive/Zafiro.Avalonia.Generators.props" />
+    <None Include="README.md" Pack="true" PackagePath="" Condition="Exists('README.md')" />
   </ItemGroup>
 </Project>

--- a/src/Zafiro.Avalonia/README.md
+++ b/src/Zafiro.Avalonia/README.md
@@ -1,0 +1,17 @@
+# Zafiro.Avalonia
+
+A UI components library for Avalonia 11.3.x. It includes controls, behaviors and helpers used across the Zafiro ecosystem.
+
+Highlights:
+- Controls and helpers for desktop, browser and mobile
+- ReactiveUI-friendly patterns
+- Optional source generator (Zafiro.Avalonia.Generators) to auto-register view locators and sections
+
+Getting started:
+- Install the package:
+  - dotnet add package Zafiro.Avalonia
+- Recommended: add Zafiro.Avalonia.Generators to enable generator-based registrations
+
+Links:
+- Samples: samples/TestApp
+- CI: Azure Pipelines (publishing via DotnetDeployer)

--- a/src/Zafiro.Avalonia/Zafiro.Avalonia.csproj
+++ b/src/Zafiro.Avalonia/Zafiro.Avalonia.csproj
@@ -29,6 +29,8 @@
 
     <ItemGroup>
         <AdditionalFiles Include="**/*.axaml" />
+        <!-- Pack project-specific README if present -->
+        <None Include="README.md" Pack="true" PackagePath="" Condition="Exists('README.md')" />
     </ItemGroup>
 
     <ItemGroup Condition="'$(UseLocalZafiroReferences)' == 'true'">


### PR DESCRIPTION
This PR improves packaging and feeds.\n\nChanges\n- Add repo-level nuget.config mapped to nuget.org only (silence NU1507)\n- Enable README in packages via Common.props and include project README.md files\n- Enable SourceLink + snupkg symbols in Common.props\n\nWhy\n- Clean, deterministic feeds and no NU1507 noise\n- Better NuGet package quality (README) and debugging (SourceLink, symbols)\n\nCI\n- Azure Pipelines continues publishing via DotnetDeployer on master.