### PR TITLE
Fix: CI NuGet packaging (README, SourceLink, analyzer snupkg)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -27,6 +27,7 @@
         <PackageVersion Include="JetBrains.Annotations" Version="2024.3.0"/>
         <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.8.0"/>
         <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.10.0"/>
+        <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0"/>
         <PackageVersion Include="Projektanker.Icons.Avalonia" Version="9.6.2"/>
         <PackageVersion Include="Projektanker.Icons.Avalonia.FontAwesome" Version="9.6.2"/>
         <PackageVersion Include="Projektanker.Icons.Avalonia.MaterialDesign" Version="9.6.2"/>

--- a/src/Common.props
+++ b/src/Common.props
@@ -22,11 +22,15 @@
 		<None Include="..\..\icon.png" Pack="true" PackagePath=""/>
 	</ItemGroup>
 
-	<!-- Package Readme: include repo README.md if present -->
+	<!-- Package Readme: prefer project README.md; fallback to repo README.md if project one is missing -->
 	<PropertyGroup>
-		<PackageReadmeFile Condition="Exists('..\\..\\README.md')">README.md</PackageReadmeFile>
+		<PackageReadmeFile Condition="Exists('README.md')">README.md</PackageReadmeFile>
+		<PackageReadmeFile Condition="'$(PackageReadmeFile)' == '' and Exists('..\\..\\README.md')">README.md</PackageReadmeFile>
 	</PropertyGroup>
-	<ItemGroup Condition="Exists('..\\..\\README.md')">
+	<ItemGroup Condition="Exists('README.md')">
+		<None Include="README.md" Pack="true" PackagePath=""/>
+	</ItemGroup>
+	<ItemGroup Condition="'$(PackageReadmeFile)' == 'README.md' and !Exists('README.md') and Exists('..\\..\\README.md')">
 		<None Include="..\..\README.md" Pack="true" PackagePath=""/>
 	</ItemGroup>
 
@@ -39,7 +43,7 @@
 		<ContinuousIntegrationBuild Condition=" '$(ContinuousIntegrationBuild)' == '' ">true</ContinuousIntegrationBuild>
 	</PropertyGroup>
 	<ItemGroup>
-		<PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All" Version="8.0.0" />
+		<PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All" />
 	</ItemGroup>
 
 </Project>

--- a/src/Zafiro.Avalonia.DataViz/Zafiro.Avalonia.DataViz.csproj
+++ b/src/Zafiro.Avalonia.DataViz/Zafiro.Avalonia.DataViz.csproj
@@ -8,7 +8,6 @@
 
     <ItemGroup>
         <AvaloniaResource Include="Assets\**" />
-        <None Include="README.md" Pack="true" PackagePath="" Condition="Exists('README.md')" />
     </ItemGroup>
 
     <Import Project="..\Common.props" />

--- a/src/Zafiro.Avalonia.Dialogs/Zafiro.Avalonia.Dialogs.csproj
+++ b/src/Zafiro.Avalonia.Dialogs/Zafiro.Avalonia.Dialogs.csproj
@@ -20,9 +20,8 @@
         <!-- Run the source generator locally as an Analyzer during in-repo builds and packing -->
         <ProjectReference Include="..\Zafiro.Avalonia.Generators\Zafiro.Avalonia.Generators.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
     </ItemGroup>
-    <!-- Make .axaml files visible to the generator and pack README -->
+    <!-- Make .axaml files visible to the generator -->
     <ItemGroup>
         <AdditionalFiles Include="**/*.axaml" />
-        <None Include="README.md" Pack="true" PackagePath="" Condition="Exists('README.md')" />
     </ItemGroup>
 </Project>

--- a/src/Zafiro.Avalonia.Generators/Zafiro.Avalonia.Generators.csproj
+++ b/src/Zafiro.Avalonia.Generators/Zafiro.Avalonia.Generators.csproj
@@ -6,8 +6,14 @@
     <IsPackable>true</IsPackable>
     <IncludeBuildOutput>false</IncludeBuildOutput>
     <OutputItemType>Analyzer</OutputItemType>
+    <!-- Do not produce snupkg for analyzer-only package to avoid NU5017 -->
+    <IncludeSymbols>false</IncludeSymbols>
   </PropertyGroup>
   <Import Project="..\Common.props" />
+  <!-- Override common symbols settings: analyzer-only package should not produce snupkg -->
+  <PropertyGroup>
+    <IncludeSymbols>false</IncludeSymbols>
+  </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" PrivateAssets="all" />
   </ItemGroup>
@@ -18,6 +24,5 @@
   <ItemGroup>
     <None Include="$(OutputPath)$(AssemblyName).dll" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
     <None Include="buildTransitive/Zafiro.Avalonia.Generators.props" Pack="true" PackagePath="buildTransitive/Zafiro.Avalonia.Generators.props" />
-    <None Include="README.md" Pack="true" PackagePath="" Condition="Exists('README.md')" />
   </ItemGroup>
 </Project>

--- a/src/Zafiro.Avalonia/Zafiro.Avalonia.csproj
+++ b/src/Zafiro.Avalonia/Zafiro.Avalonia.csproj
@@ -29,8 +29,6 @@
 
     <ItemGroup>
         <AdditionalFiles Include="**/*.axaml" />
-        <!-- Pack project-specific README if present -->
-        <None Include="README.md" Pack="true" PackagePath="" Condition="Exists('README.md')" />
     </ItemGroup>
 
     <ItemGroup Condition="'$(UseLocalZafiroReferences)' == 'true'">


### PR DESCRIPTION
This PR fixes the CI break introduced by package README/SourceLink changes.\n\nFixes\n- Centralize README inclusion in Common.props to avoid duplicates across projects\n- Make SourceLink version CPM-friendly (Directory.Packages.props)\n- Disable snupkg for analyzer-only package to avoid NU5017 during pack\n\nLocal verification\n- dotnet restore/build succeeded\n- dotnet pack for Zafiro.Avalonia.Generators succeeds (NU5128 warning expected for analyzers)\n\nCI\n- Publishing via DotnetDeployer should pass again on master.