### PR TITLE
Implement adaptive dialog sizing policy

### DIFF
--- a/src/Zafiro.Avalonia.Dialogs/DesktopDialog.cs
+++ b/src/Zafiro.Avalonia.Dialogs/DesktopDialog.cs
@@ -1,4 +1,5 @@
-﻿using Avalonia.Controls;
+﻿using Avalonia;
+using Avalonia.Controls;
 using Avalonia.Threading;
 using Zafiro.Avalonia.Dialogs.Views;
 using Zafiro.Avalonia.Misc;
@@ -15,6 +16,8 @@ public class DesktopDialog : IDialog
         {
             var mainWindow = ApplicationUtils.MainWindow().GetValueOrThrow("Cannot get the main window");
 
+            var layout = DialogSizePolicy.Calculate(new Rect(mainWindow.Bounds.Size));
+
             var window = new Window
             {
                 Title = title,
@@ -22,10 +25,12 @@ public class DesktopDialog : IDialog
                 CanResize = false,
                 Icon = mainWindow.Icon,
                 SizeToContent = SizeToContent.WidthAndHeight,
-                MaxWidth = 800,
-                MaxHeight = 800,
-                MinWidth = 300,
-                MinHeight = 200
+                Width = layout.PreferredWindow.Width,
+                Height = layout.PreferredWindow.Height,
+                MaxWidth = layout.MaximumWindow.Width,
+                MaxHeight = layout.MaximumWindow.Height,
+                MinWidth = layout.MinimumWindow.Width,
+                MinHeight = layout.MinimumWindow.Height
             };
 
             var closeable = new CloseableWrapper(window);
@@ -34,7 +39,13 @@ public class DesktopDialog : IDialog
             window.Content = new DialogControl
             {
                 Content = viewModel,
-                Options = options
+                Options = options,
+                Width = layout.PreferredContent.Width,
+                Height = layout.PreferredContent.Height,
+                MaxWidth = layout.MaximumContent.Width,
+                MaxHeight = layout.MaximumContent.Height,
+                MinWidth = layout.MinimumContent.Width,
+                MinHeight = layout.MinimumContent.Height
             };
 
             var result = await window.ShowDialog<bool?>(mainWindow).ConfigureAwait(false);

--- a/src/Zafiro.Avalonia.Dialogs/DialogManager.cs
+++ b/src/Zafiro.Avalonia.Dialogs/DialogManager.cs
@@ -1,3 +1,4 @@
+using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Threading;
 using Zafiro.Avalonia.Dialogs.Views;
@@ -31,15 +32,19 @@ namespace Zafiro.Avalonia.Dialogs
                 // Si no hay ventana de diálogo, crea una nueva
                 if (dialogWindow == null)
                 {
+                    var layout = DialogSizePolicy.Calculate(new Rect(mainWindow.Bounds.Size));
+
                     dialogWindow = new Window
                     {
                         WindowStartupLocation = WindowStartupLocation.CenterOwner,
                         Icon = mainWindow.Icon,
                         SizeToContent = SizeToContent.WidthAndHeight,
-                        MaxWidth = 800,
-                        MaxHeight = 700,
-                        MinWidth = 400,
-                        MinHeight = 300
+                        Width = layout.PreferredWindow.Width,
+                        Height = layout.PreferredWindow.Height,
+                        MaxWidth = layout.MaximumWindow.Width,
+                        MaxHeight = layout.MaximumWindow.Height,
+                        MinWidth = layout.MinimumWindow.Width,
+                        MinHeight = layout.MinimumWindow.Height
                     };
 
                     // Maneja el evento de cierre de la ventana para completar todos los diálogos pendientes
@@ -78,10 +83,25 @@ namespace Zafiro.Avalonia.Dialogs
             if (dialogWindow != null)
             {
                 dialogWindow.Title = dialogContext.Title;
+                var layout = DialogSizePolicy.Calculate(new Rect(dialogWindow.Owner?.Bounds.Size ?? dialogWindow.Bounds.Size));
+
+                dialogWindow.Width = layout.PreferredWindow.Width;
+                dialogWindow.Height = layout.PreferredWindow.Height;
+                dialogWindow.MaxWidth = layout.MaximumWindow.Width;
+                dialogWindow.MaxHeight = layout.MaximumWindow.Height;
+                dialogWindow.MinWidth = layout.MinimumWindow.Width;
+                dialogWindow.MinHeight = layout.MinimumWindow.Height;
+
                 dialogWindow.Content = new DialogControl
                 {
                     Content = dialogContext.ViewModel,
-                    Options = dialogContext.Options
+                    Options = dialogContext.Options,
+                    Width = layout.PreferredContent.Width,
+                    Height = layout.PreferredContent.Height,
+                    MaxWidth = layout.MaximumContent.Width,
+                    MaxHeight = layout.MaximumContent.Height,
+                    MinWidth = layout.MinimumContent.Width,
+                    MinHeight = layout.MinimumContent.Height
                 };
             }
         }

--- a/src/Zafiro.Avalonia.Dialogs/DialogSizePolicy.cs
+++ b/src/Zafiro.Avalonia.Dialogs/DialogSizePolicy.cs
@@ -1,0 +1,86 @@
+using System;
+using Avalonia;
+
+namespace Zafiro.Avalonia.Dialogs;
+
+public record DialogLayout(
+    Size PreferredWindow,
+    Size MinimumWindow,
+    Size MaximumWindow,
+    Size PreferredContent,
+    Size MinimumContent,
+    Size MaximumContent);
+
+public static class DialogSizePolicy
+{
+    private const double GoldenRatio = 1.6180339887498948482;
+    private const double PortraitHorizontalPaddingRatio = 0.08;
+    private const double PortraitVerticalPaddingRatio = 0.12;
+    private const double LandscapeHorizontalPaddingRatio = 0.18;
+    private const double LandscapeVerticalPaddingRatio = 0.16;
+    private const double MinimumWindowWidth = 320;
+    private const double MinimumWindowHeight = 240;
+    private const double MinimumContentWidth = 280;
+    private const double MinimumContentHeight = 220;
+    private const double HorizontalChrome = 64;
+    private const double VerticalChrome = 180;
+
+    public static DialogLayout Calculate(Rect parentBounds)
+    {
+        if (parentBounds.Width <= 0 || parentBounds.Height <= 0)
+        {
+            var defaultSize = new Size(MinimumWindowWidth, MinimumWindowHeight);
+            var defaultContent = new Size(MinimumContentWidth, MinimumContentHeight);
+            return new DialogLayout(defaultSize, defaultSize, defaultSize, defaultContent, defaultContent, defaultContent);
+        }
+
+        var orientation = parentBounds.Width >= parentBounds.Height ? Orientation.Landscape : Orientation.Portrait;
+
+        var horizontalPaddingRatio = orientation == Orientation.Landscape
+            ? LandscapeHorizontalPaddingRatio
+            : PortraitHorizontalPaddingRatio;
+
+        var verticalPaddingRatio = orientation == Orientation.Landscape
+            ? LandscapeVerticalPaddingRatio
+            : PortraitVerticalPaddingRatio;
+
+        var maxWidth = Math.Max(parentBounds.Width * (1 - horizontalPaddingRatio), MinimumWindowWidth);
+        var maxHeight = Math.Max(parentBounds.Height * (1 - verticalPaddingRatio), MinimumWindowHeight);
+
+        var preferredWidth = Math.Clamp(parentBounds.Width / GoldenRatio, MinimumWindowWidth, maxWidth);
+        var preferredHeightFromWidth = preferredWidth / GoldenRatio;
+        var preferredHeight = Math.Clamp(preferredHeightFromWidth, MinimumWindowHeight, maxHeight);
+
+        if (preferredHeight >= maxHeight)
+        {
+            preferredHeight = maxHeight;
+            preferredWidth = Math.Clamp(preferredHeight * GoldenRatio, MinimumWindowWidth, maxWidth);
+        }
+
+        var minWidth = Math.Min(preferredWidth, Math.Max(MinimumWindowWidth, maxWidth * 0.5));
+        var minHeight = Math.Min(preferredHeight, Math.Max(MinimumWindowHeight, maxHeight * 0.5));
+
+        var preferredContentWidth = Math.Max(MinimumContentWidth, preferredWidth - HorizontalChrome);
+        var preferredContentHeight = Math.Max(MinimumContentHeight, preferredHeight - VerticalChrome);
+
+        var minContentWidth = Math.Min(preferredContentWidth, Math.Max(MinimumContentWidth, minWidth - HorizontalChrome));
+        var minContentHeight = Math.Min(preferredContentHeight, Math.Max(MinimumContentHeight, minHeight - VerticalChrome));
+
+        var maxContentWidth = Math.Max(MinimumContentWidth, maxWidth - HorizontalChrome);
+        var maxContentHeight = Math.Max(MinimumContentHeight, maxHeight - VerticalChrome);
+
+        return new DialogLayout(
+            new Size(preferredWidth, preferredHeight),
+            new Size(minWidth, minHeight),
+            new Size(maxWidth, maxHeight),
+            new Size(preferredContentWidth, preferredContentHeight),
+            new Size(minContentWidth, minContentHeight),
+            new Size(maxContentWidth, maxContentHeight));
+    }
+
+    private enum Orientation
+    {
+        Portrait,
+        Landscape,
+    }
+}


### PR DESCRIPTION
## Summary
- add a reusable dialog size policy that computes harmonic window and content bounds
- apply the adaptive layout to desktop, stacked, and adorner-backed dialogs so they size gracefully on any viewport

## Testing
- `MSBUILDTERMINALLOGGER=false dotnet build` *(fails: requires android and wasm workloads)*

------
https://chatgpt.com/codex/tasks/task_e_68df9436dd0c832f8973ae87b0be91ce