### PR TITLE
feat: Migrate to Avalonia 12 +semversion:major

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -2,50 +2,56 @@
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
-    <AvaloniaVersion>11.3.12</AvaloniaVersion>
+    <AvaloniaVersion>12.0.0</AvaloniaVersion>
   </PropertyGroup>
   <ItemGroup>
+      <!-- Avalonia 12 core -->
       <PackageVersion Include="Avalonia" Version="$(AvaloniaVersion)"/>
       <PackageVersion Include="Avalonia.Android" Version="$(AvaloniaVersion)"/>
       <PackageVersion Include="Avalonia.Browser" Version="$(AvaloniaVersion)"/>
       <PackageVersion Include="Avalonia.Controls.DataGrid" Version="$(AvaloniaVersion)"/>
-      <PackageVersion Include="Avalonia.Controls.PanAndZoom" Version="11.3.0"/>
       <PackageVersion Include="Avalonia.Desktop" Version="$(AvaloniaVersion)"/>
       <PackageVersion Include="Avalonia.Fonts.Inter" Version="$(AvaloniaVersion)"/>
-      <PackageVersion Include="Avalonia.Headless.XUnit" Version="11.3.12"/>
+      <PackageVersion Include="Avalonia.Headless.XUnit" Version="$(AvaloniaVersion)"/>
       <PackageVersion Include="Avalonia.iOS" Version="$(AvaloniaVersion)"/>
-      <PackageVersion Include="Avalonia.ReactiveUI" Version="11.3.8"/>
+      <PackageVersion Include="Avalonia.Skia" Version="$(AvaloniaVersion)"/>
       <PackageVersion Include="Avalonia.Themes.Fluent" Version="$(AvaloniaVersion)"/>
       <PackageVersion Include="AvaloniaUI.DiagnosticsSupport" Version="2.2.0-beta3"/>
+
+      <!-- Avalonia 12 ecosystem -->
+      <PackageVersion Include="ReactiveUI.Avalonia" Version="11.3.8"/>
+      <PackageVersion Include="Svg.Controls.Skia.Avalonia" Version="12.0.0"/>
+      <PackageVersion Include="Xaml.Behaviors.Avalonia" Version="12.0.0"/>
+      <PackageVersion Include="Xaml.Behaviors.Interactions.DragAndDrop" Version="12.0.0"/>
+      <PackageVersion Include="Xaml.Behaviors.Interactions.Draggable" Version="12.0.0"/>
+      <PackageVersion Include="Xaml.Behaviors.Interactions.Events" Version="12.0.0"/>
+
+      <!-- Temporarily excluded from solution (awaiting Av12 support) -->
+      <PackageVersion Include="PanAndZoom" Version="11.3.6"/>
+      <PackageVersion Include="Projektanker.Icons.Avalonia" Version="9.6.2"/>
+      <PackageVersion Include="Projektanker.Icons.Avalonia.FontAwesome" Version="9.6.2"/>
+      <PackageVersion Include="Projektanker.Icons.Avalonia.MaterialDesign" Version="9.6.2"/>
+
+      <!-- ReactiveUI -->
+      <PackageVersion Include="ReactiveProperty" Version="9.8.0"/>
+      <PackageVersion Include="ReactiveUI" Version="22.2.1"/>
+      <PackageVersion Include="ReactiveUI.SourceGenerators" Version="2.5.1"/>
+      <PackageVersion Include="ReactiveUI.Validation" Version="6.0.5"/>
+
+      <!-- Infrastructure -->
       <PackageVersion Include="coverlet.collector" Version="6.0.4"/>
       <PackageVersion Include="CSharpFunctionalExtensions" Version="3.6.0"/>
-      <PackageVersion Include="Deadpikle.AvaloniaProgressRing" Version="0.10.10"/>
-      <PackageVersion Include="FluentAvaloniaUI" Version="2.4.1"/>
       <PackageVersion Include="HttpClient.Extensions.LoggingHttpMessageHandler" Version="1.0.3"/>
       <PackageVersion Include="JetBrains.Annotations" Version="2025.2.2"/>
       <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.8.0"/>
       <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.14.0"/>
       <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0"/>
-      <PackageVersion Include="PanAndZoom" Version="11.3.6"/>
-      <PackageVersion Include="Projektanker.Icons.Avalonia" Version="9.6.2"/>
-      <PackageVersion Include="Projektanker.Icons.Avalonia.FontAwesome" Version="9.6.2"/>
-      <PackageVersion Include="Projektanker.Icons.Avalonia.MaterialDesign" Version="9.6.2"/>
-      <PackageVersion Include="ReactiveProperty" Version="9.8.0"/>
-      <PackageVersion Include="ReactiveUI" Version="22.2.1"/>
-      <PackageVersion Include="ReactiveUI.Avalonia" Version="11.3.8"/>
-      <PackageVersion Include="ReactiveUI.SourceGenerators" Version="2.5.1"/>
-      <PackageVersion Include="ReactiveUI.Validation" Version="6.0.5"/>
       <PackageVersion Include="Serilog" Version="4.3.0"/>
       <PackageVersion Include="Serilog.Sinks.Console" Version="6.0.0"/>
-      <PackageVersion Include="Svg.Controls.Skia.Avalonia" Version="11.3.9.2"/>
       <PackageVersion Include="System.Linq.Async" Version="6.0.3"/>
       <PackageVersion Include="Xamarin.AndroidX.Core.SplashScreen" Version="1.0.1.17"/>
-      <PackageVersion Include="Xaml.Behaviors.Avalonia" Version="11.3.8.2"/>
-      <PackageVersion Include="Xaml.Behaviors.Interactions.DragAndDrop" Version="11.3.8.2"/>
-      <PackageVersion Include="Xaml.Behaviors.Interactions.Draggable" Version="11.3.8.2"/>
-      <PackageVersion Include="Xaml.Behaviors.Interactions.Events" Version="11.3.8.2"/>
-      <PackageVersion Include="xunit" Version="2.5.3"/>
-      <PackageVersion Include="xunit.runner.visualstudio" Version="2.5.3"/>
+      <PackageVersion Include="xunit.v3" Version="3.2.2"/>
+      <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.0"/>
       <PackageVersion Include="Zafiro.UI" Version="47.0.2"/>
   </ItemGroup>
 </Project>

--- a/Zafiro.Avalonia.sln
+++ b/Zafiro.Avalonia.sln
@@ -7,16 +7,6 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Zafiro.Avalonia.Dialogs", "
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Zafiro.Avalonia", "src\Zafiro.Avalonia\Zafiro.Avalonia.csproj", "{7E270C24-4440-4BDB-889D-6CA65C082AD1}"
 EndProject
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Samples", "Samples", "{022A4D50-4916-4866-833D-89E8A1C3E90B}"
-EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TestApp", "samples\TestApp\TestApp\TestApp.csproj", "{0B28296D-9B99-45C7-B9AC-6EBB7DCF22A1}"
-EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TestApp.Desktop", "samples\TestApp\TestApp.Desktop\TestApp.Desktop.csproj", "{562DA12A-1D8E-4DB8-9279-059677AED984}"
-EndProject
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "ControlLibrary", "ControlLibrary", "{41A6E3E0-9492-4B68-B308-40F2A7ED0623}"
-EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Zafiro.Avalonia.DataViz", "src\Zafiro.Avalonia.DataViz\Zafiro.Avalonia.DataViz.csproj", "{ACAFB523-C9C0-47BA-9870-7148DE5C0835}"
-EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Zafiro.Avalonia.Generators", "src\Zafiro.Avalonia.Generators\Zafiro.Avalonia.Generators.csproj", "{D2993F32-C840-4A28-BBC4-986DF7299073}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Other files", "Other files", "{5C17C740-EF9B-4539-92BB-43CE92250490}"
@@ -25,8 +15,6 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Other files", "Other files"
 		src\Common.props = src\Common.props
 		Directory.Packages.props = Directory.Packages.props
 	EndProjectSection
-EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Zafiro.Avalonia.Icons.Projektanker", "src\Zafiro.Avalonia.Icons.Projektanker\Zafiro.Avalonia.Icons.Projektanker.csproj", "{7AB81EA9-F3F5-4732-BD23-9805747CEB34}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Zafiro.Avalonia.Icons.Svg", "src\Zafiro.Avalonia.Icons.Svg\Zafiro.Avalonia.Icons.Svg.csproj", "{0654A361-009C-4E76-BD70-37D76A9A47A7}"
 EndProject
@@ -46,26 +34,10 @@ Global
 		{7E270C24-4440-4BDB-889D-6CA65C082AD1}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{7E270C24-4440-4BDB-889D-6CA65C082AD1}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{7E270C24-4440-4BDB-889D-6CA65C082AD1}.Release|Any CPU.Build.0 = Release|Any CPU
-		{0B28296D-9B99-45C7-B9AC-6EBB7DCF22A1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{0B28296D-9B99-45C7-B9AC-6EBB7DCF22A1}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{0B28296D-9B99-45C7-B9AC-6EBB7DCF22A1}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{0B28296D-9B99-45C7-B9AC-6EBB7DCF22A1}.Release|Any CPU.Build.0 = Release|Any CPU
-		{562DA12A-1D8E-4DB8-9279-059677AED984}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{562DA12A-1D8E-4DB8-9279-059677AED984}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{562DA12A-1D8E-4DB8-9279-059677AED984}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{562DA12A-1D8E-4DB8-9279-059677AED984}.Release|Any CPU.Build.0 = Release|Any CPU
-		{ACAFB523-C9C0-47BA-9870-7148DE5C0835}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{ACAFB523-C9C0-47BA-9870-7148DE5C0835}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{ACAFB523-C9C0-47BA-9870-7148DE5C0835}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{ACAFB523-C9C0-47BA-9870-7148DE5C0835}.Release|Any CPU.Build.0 = Release|Any CPU
 		{D2993F32-C840-4A28-BBC4-986DF7299073}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{D2993F32-C840-4A28-BBC4-986DF7299073}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{D2993F32-C840-4A28-BBC4-986DF7299073}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{D2993F32-C840-4A28-BBC4-986DF7299073}.Release|Any CPU.Build.0 = Release|Any CPU
-		{7AB81EA9-F3F5-4732-BD23-9805747CEB34}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{7AB81EA9-F3F5-4732-BD23-9805747CEB34}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{7AB81EA9-F3F5-4732-BD23-9805747CEB34}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{7AB81EA9-F3F5-4732-BD23-9805747CEB34}.Release|Any CPU.Build.0 = Release|Any CPU
 		{0654A361-009C-4E76-BD70-37D76A9A47A7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{0654A361-009C-4E76-BD70-37D76A9A47A7}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{0654A361-009C-4E76-BD70-37D76A9A47A7}.Release|Any CPU.ActiveCfg = Release|Any CPU
@@ -77,11 +49,6 @@ Global
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
-	EndGlobalSection
-	GlobalSection(NestedProjects) = preSolution
-		{0B28296D-9B99-45C7-B9AC-6EBB7DCF22A1} = {41A6E3E0-9492-4B68-B308-40F2A7ED0623}
-		{562DA12A-1D8E-4DB8-9279-059677AED984} = {41A6E3E0-9492-4B68-B308-40F2A7ED0623}
-		{41A6E3E0-9492-4B68-B308-40F2A7ED0623} = {022A4D50-4916-4866-833D-89E8A1C3E90B}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {E64CD420-15B1-487C-9806-41EBE6DC15A4}

--- a/samples/TestApp/TestApp/Samples/Layout/FlexPanelView.axaml
+++ b/samples/TestApp/TestApp/Samples/Layout/FlexPanelView.axaml
@@ -21,6 +21,11 @@
             <Setter Property="Background" Value="#08FFFFFF" />
         </Style>
 
+        <Style Selector="FlexPanel > Button">
+            <Setter Property="HorizontalAlignment" Value="Stretch" />
+            <Setter Property="VerticalAlignment" Value="Stretch" />
+        </Style>
+
         <Style Selector="GridSplitter.demo-resizer">
             <Setter Property="ResizeDirection" Value="Columns" />
             <Setter Property="MinWidth" Value="16" />
@@ -211,6 +216,60 @@
                                 </StackPanel>
                             </Border>
                         </FlexPanel>
+                    </Border>
+                    <GridSplitter Grid.Column="1" Classes="demo-resizer" />
+                    <Panel Grid.Column="2" />
+                </Grid>
+            </Card>
+
+            <Card Header="Wrap-to-Fill Buttons (flex-grow: 1 + flex-basis per size)">
+                <Grid ColumnDefinitions="3*, Auto, *">
+                    <Border Grid.Column="0" Classes="demo-surface" ClipToBounds="True" MinWidth="180">
+                        <StackPanel Spacing="10">
+                            <TextBlock TextWrapping="Wrap"
+                                       Text="Every button has Grow=1 so items on the same line share extra space equally. Each one has a different Basis that sets its ideal width before growing. When the container shrinks, buttons wrap and still fill their row. Drag the grip to resize." />
+
+                            <FlexPanel Wrap="Wrap" Gap="8" AlignContent="Start">
+                                <Button Content="Cancelar"
+                                        FontSize="12" Padding="10,4"
+                                        FlexPanel.Grow="1" FlexPanel.Basis="60" />
+                                <Button Content="Ver detalles"
+                                        FontSize="13" Padding="13,5"
+                                        Background="#DBEAFE" Foreground="#1E40AF"
+                                        FlexPanel.Grow="1" FlexPanel.Basis="90" />
+                                <Button Content="Guardar borrador"
+                                        FontSize="14" Padding="16,6"
+                                        FlexPanel.Grow="1" FlexPanel.Basis="120" />
+                                <Button Content="⏳ Pendiente"
+                                        FontSize="13" Padding="13,5"
+                                        Background="#FEF3C7" Foreground="#92400E"
+                                        FlexPanel.Grow="1" FlexPanel.Basis="90" />
+                                <Button Content="Publicar ahora"
+                                        FontSize="15" Padding="20,8"
+                                        Background="#1E293B" Foreground="White"
+                                        FlexPanel.Grow="1" FlexPanel.Basis="150" />
+                                <Button Content="Eliminar"
+                                        FontSize="12" Padding="10,4"
+                                        Background="#FEE2E2" Foreground="#991B1B"
+                                        FlexPanel.Grow="1" FlexPanel.Basis="60" />
+                                <Button Content="Confirmar pedido"
+                                        FontSize="16" Padding="26,10"
+                                        Background="#D1FAE5" Foreground="#065F46"
+                                        FlexPanel.Grow="1" FlexPanel.Basis="190" />
+                                <Button Content="Duplicar"
+                                        FontSize="13" Padding="13,5"
+                                        FlexPanel.Grow="1" FlexPanel.Basis="90" />
+                                <Button Content="Exportar PDF"
+                                        FontSize="14" Padding="16,6"
+                                        FlexPanel.Grow="1" FlexPanel.Basis="120" />
+                                <Button Content="Filtros"
+                                        FontSize="12" Padding="10,4"
+                                        FlexPanel.Grow="1" FlexPanel.Basis="60" />
+                                <Button Content="Compartir enlace"
+                                        FontSize="15" Padding="20,8"
+                                        FlexPanel.Grow="1" FlexPanel.Basis="150" />
+                            </FlexPanel>
+                        </StackPanel>
                     </Border>
                     <GridSplitter Grid.Column="1" Classes="demo-resizer" />
                     <Panel Grid.Column="2" />

--- a/src/Zafiro.Avalonia/Behaviors/AddClassWhenUnmodifiedBehavior.cs
+++ b/src/Zafiro.Avalonia/Behaviors/AddClassWhenUnmodifiedBehavior.cs
@@ -76,7 +76,7 @@ public class UntouchedClassBehavior : Behavior<Control>
         disposables.Dispose();
         if (AssociatedObject != null)
         {
-            if (AssociatedObject.GetVisualRoot() is { })
+            if (AssociatedObject.IsAttachedToVisualTree())
             {
                 AssociatedObject.Classes.Remove(ClassName);
             }
@@ -85,7 +85,7 @@ public class UntouchedClassBehavior : Behavior<Control>
 
     private void OnTextChanged()
     {
-        if (!hasBeenModified && AssociatedObject?.GetVisualRoot() is { })
+        if (!hasBeenModified && AssociatedObject is { } obj && obj.IsAttachedToVisualTree())
         {
             hasBeenModified = true;
             AssociatedObject.Classes.Remove(ClassName);

--- a/src/Zafiro.Avalonia/Behaviors/NumberBoxBehavior.cs
+++ b/src/Zafiro.Avalonia/Behaviors/NumberBoxBehavior.cs
@@ -1,6 +1,7 @@
 using System.Globalization;
 using System.Reactive.Disposables;
 using Avalonia.Input;
+using Avalonia.Input.Platform;
 using Avalonia.Interactivity;
 using Avalonia.Xaml.Interactivity;
 using CSharpFunctionalExtensions;
@@ -47,7 +48,7 @@ public class NumberBoxBehavior : Behavior<TextBox>
     private static Task<string> GetClipboardText()
     {
         return ApplicationUtils.GetClipboard()
-            .Map(clipboard => clipboard.GetTextAsync())
+            .Map(clipboard => clipboard.TryGetTextAsync())
             .GetValueOrDefault(_ => "")!;
     }
 

--- a/src/Zafiro.Avalonia/Commands.cs
+++ b/src/Zafiro.Avalonia/Commands.cs
@@ -1,3 +1,4 @@
+using Avalonia.Input.Platform;
 using CSharpFunctionalExtensions;
 using Zafiro.Avalonia.Misc;
 using Zafiro.Avalonia.Services;

--- a/src/Zafiro.Avalonia/Controls/Diagrams/Simple/DiagramView.axaml
+++ b/src/Zafiro.Avalonia/Controls/Diagrams/Simple/DiagramView.axaml
@@ -32,8 +32,8 @@
                                     <BehaviorCollectionTemplate>
                                         <BehaviorCollection>
                                             <behaviors:DragDeltaBehavior
-                                                Left="{Binding Left}"
-                                                Top="{Binding Top}" />
+                                                Left="{ReflectionBinding Left}"
+                                                Top="{ReflectionBinding Top}" />
                                         </BehaviorCollection>
                                     </BehaviorCollectionTemplate>
                                 </Setter>

--- a/src/Zafiro.Avalonia/Controls/Loading.axaml
+++ b/src/Zafiro.Avalonia/Controls/Loading.axaml
@@ -1,7 +1,7 @@
 <Styles xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:controls="clr-namespace:Zafiro.Avalonia.Controls"
-        xmlns:c="clr-namespace:FluentAvalonia.UI.Controls;assembly=FluentAvalonia">
+        xmlns:c="clr-namespace:Zafiro.Avalonia.Controls">
     <Styles.Resources>
         <ControlTheme x:Key="{x:Type controls:Loading}" TargetType="{x:Type controls:Loading}">
             <Setter Property="LoadingTemplate">

--- a/src/Zafiro.Avalonia/Controls/Panels/SmartWrapPanel.cs
+++ b/src/Zafiro.Avalonia/Controls/Panels/SmartWrapPanel.cs
@@ -5,7 +5,6 @@
 
 using Avalonia.Input;
 using Avalonia.Layout;
-using Avalonia.Utilities;
 using static System.Math;
 
 namespace Zafiro.Avalonia.Controls.Panels;
@@ -149,13 +148,13 @@ public class SmartWrapPanel : Panel, INavigableContainer
                 itemWidthSet ? itemWidth : child.DesiredSize.Width,
                 itemHeightSet ? itemHeight : child.DesiredSize.Height);
 
-            if (MathUtilities.GreaterThan(curLineSize.U + sz.U, uvConstraint.U)) // Need to switch to another line
+            if (GreaterThan(curLineSize.U + sz.U, uvConstraint.U)) // Need to switch to another line
             {
                 panelSize.U = Max(curLineSize.U, panelSize.U);
                 panelSize.V += curLineSize.V;
                 curLineSize = sz;
 
-                if (MathUtilities.GreaterThan(sz.U, uvConstraint.U)) // The element is wider then the constraint - give it a separate line
+                if (GreaterThan(sz.U, uvConstraint.U)) // The element is wider then the constraint - give it a separate line
                 {
                     panelSize.U = Max(sz.U, panelSize.U);
                     panelSize.V += sz.V;
@@ -200,14 +199,14 @@ public class SmartWrapPanel : Panel, INavigableContainer
                 itemWidthSet ? itemWidth : child.DesiredSize.Width,
                 itemHeightSet ? itemHeight : child.DesiredSize.Height);
 
-            if (MathUtilities.GreaterThan(curLineSize.U + sz.U, uvFinalSize.U)) // Needs to move to another line
+            if (GreaterThan(curLineSize.U + sz.U, uvFinalSize.U)) // Needs to move to another line
             {
                 ArrangeLine(accumulatedV, curLineSize.V, firstInLine, i, useItemU, itemU);
 
                 accumulatedV += curLineSize.V;
                 curLineSize = sz;
 
-                if (MathUtilities.GreaterThan(sz.U, uvFinalSize.U)) // The element is wider than the available space
+                if (GreaterThan(sz.U, uvFinalSize.U)) // The element is wider than the available space
                 {
                     // Move to the next line that only contains one element
                     ArrangeLine(accumulatedV, sz.V, i, i + 1, useItemU, itemU);
@@ -256,6 +255,11 @@ public class SmartWrapPanel : Panel, INavigableContainer
                 isHorizontal ? lineV : layoutSlotU));
             u += layoutSlotU;
         }
+    }
+
+    private static bool GreaterThan(double value1, double value2)
+    {
+        return value1 > value2 && Abs(value1 - value2) > double.Epsilon;
     }
 
     private struct UVSize

--- a/src/Zafiro.Avalonia/Controls/ProgressRing/ProgressRing.cs
+++ b/src/Zafiro.Avalonia/Controls/ProgressRing/ProgressRing.cs
@@ -1,0 +1,62 @@
+// Based on FluentAvalonia ProgressRing by amwx
+// Original source: https://github.com/amwx/FluentAvalonia
+// License: MIT — Copyright (c) 2025 amwx
+
+using Avalonia;
+using Avalonia.Controls.Metadata;
+using Avalonia.Controls.Primitives;
+using Avalonia.Media;
+
+namespace Zafiro.Avalonia.Controls;
+
+[TemplatePart(TemplatePartAnimatedVisual, typeof(ProgressRingAnimatedVisual))]
+public class ProgressRing : RangeBase
+{
+    public static readonly StyledProperty<bool> IsActiveProperty =
+        AvaloniaProperty.Register<ProgressRing, bool>(nameof(IsActive), true);
+
+    public static readonly StyledProperty<bool> IsIndeterminateProperty =
+        ProgressBar.IsIndeterminateProperty.AddOwner<ProgressRing>(
+            new StyledPropertyMetadata<bool>(defaultValue: true));
+
+    public bool IsActive
+    {
+        get => GetValue(IsActiveProperty);
+        set => SetValue(IsActiveProperty, value);
+    }
+
+    public bool IsIndeterminate
+    {
+        get => GetValue(IsIndeterminateProperty);
+        set => SetValue(IsIndeterminateProperty, value);
+    }
+
+    protected override void OnApplyTemplate(TemplateAppliedEventArgs e)
+    {
+        base.OnApplyTemplate(e);
+        _animatedVisualSource = e.NameScope.Get<ProgressRingAnimatedVisual>(TemplatePartAnimatedVisual);
+    }
+
+    protected override void OnPropertyChanged(AvaloniaPropertyChangedEventArgs change)
+    {
+        base.OnPropertyChanged(change);
+
+        if (change.Property == ValueProperty)
+            _animatedVisualSource?.SetValue(change.GetNewValue<double>());
+        else if (change.Property == MinimumProperty)
+            _animatedVisualSource?.SetMinimum(change.GetNewValue<double>());
+        else if (change.Property == MaximumProperty)
+            _animatedVisualSource?.SetMaximum(change.GetNewValue<double>());
+        else if (change.Property == IsIndeterminateProperty)
+            _animatedVisualSource?.SetIndeterminate(change.GetNewValue<bool>());
+        else if (change.Property == IsActiveProperty)
+            _animatedVisualSource?.SetActive(change.GetNewValue<bool>());
+        else if (change.Property == ForegroundProperty)
+            _animatedVisualSource?.SetForeground((IBrush)change.NewValue!);
+        else if (change.Property == BackgroundProperty)
+            _animatedVisualSource?.SetBackground((IBrush)change.NewValue!);
+    }
+
+    private ProgressRingAnimatedVisual? _animatedVisualSource;
+    private const string TemplatePartAnimatedVisual = "AnimatedVisual";
+}

--- a/src/Zafiro.Avalonia/Controls/ProgressRing/ProgressRingAnimatedVisual.cs
+++ b/src/Zafiro.Avalonia/Controls/ProgressRing/ProgressRingAnimatedVisual.cs
@@ -1,0 +1,306 @@
+// Based on FluentAvalonia ProgressRingAnimatedVisual by amwx
+// Original source: https://github.com/amwx/FluentAvalonia
+// License: MIT — Copyright (c) 2025 amwx
+
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Media;
+using Avalonia.Platform;
+using Avalonia.Rendering.Composition;
+using Avalonia.Skia;
+using Avalonia.VisualTree;
+using SkiaSharp;
+
+namespace Zafiro.Avalonia.Controls;
+
+/// <summary>
+/// Animated visual source for <see cref="ProgressRing"/>.
+/// Public only for XAML template support.
+/// </summary>
+public sealed class ProgressRingAnimatedVisual : Control
+{
+    protected override void OnAttachedToVisualTree(VisualTreeAttachmentEventArgs e)
+    {
+        base.OnAttachedToVisualTree(e);
+
+        var parent = this.FindAncestorOfType<ProgressRing>();
+        if (parent is null) return;
+
+        _handler = new CompositionHandler(
+            parent.Minimum, parent.Maximum, parent.Value,
+            parent.IsActive, parent.Background, parent.Foreground);
+
+        if (_compositionVisual == null)
+        {
+            var vis = ElementComposition.GetElementVisual(this);
+            if (vis is null) return;
+
+            var comp = vis.Compositor;
+            _compositionVisual = comp.CreateCustomVisual(_handler);
+            _compositionVisual.Size = new Vector(80, 80);
+            ElementComposition.SetElementChildVisual(this, _compositionVisual);
+        }
+
+        _compositionVisual.SendHandlerMessage(
+            new HandlerMessage(MessageType.Indeterminate, parent.IsIndeterminate));
+    }
+
+    protected override void OnSizeChanged(SizeChangedEventArgs e)
+    {
+        base.OnSizeChanged(e);
+        var minSize = Math.Min(e.NewSize.Width, e.NewSize.Height);
+        _compositionVisual?.SendHandlerMessage(
+            new HandlerMessage(MessageType.Scale, minSize / 80.0));
+    }
+
+    internal void SetMinimum(double min) =>
+        _compositionVisual?.SendHandlerMessage(new HandlerMessage(MessageType.Min, (float)min));
+
+    internal void SetMaximum(double max) =>
+        _compositionVisual?.SendHandlerMessage(new HandlerMessage(MessageType.Max, (float)max));
+
+    internal void SetValue(double val) =>
+        _compositionVisual?.SendHandlerMessage(new HandlerMessage(MessageType.Value, (float)val));
+
+    internal void SetActive(bool active) =>
+        _compositionVisual?.SendHandlerMessage(new HandlerMessage(MessageType.Active, active));
+
+    internal void SetIndeterminate(bool indeterminate) =>
+        _compositionVisual?.SendHandlerMessage(new HandlerMessage(MessageType.Indeterminate, indeterminate));
+
+    internal void SetBackground(IBrush brush)
+    {
+        _compositionVisual?.SendHandlerMessage(brush is ISolidColorBrush scb
+            ? new HandlerMessage(MessageType.Background, scb.Color.ToSKColor())
+            : new HandlerMessage(MessageType.Background, null));
+    }
+
+    internal void SetForeground(IBrush brush)
+    {
+        _compositionVisual?.SendHandlerMessage(brush is ISolidColorBrush scb
+            ? new HandlerMessage(MessageType.Foreground, scb.Color.ToSKColor())
+            : new HandlerMessage(MessageType.Foreground, SKColors.Transparent));
+    }
+
+    private CompositionHandler? _handler;
+    private CompositionCustomVisual? _compositionVisual;
+
+    private enum MessageType
+    {
+        Background, Foreground, Min, Max, Value, Active, Indeterminate, Scale
+    }
+
+    private sealed class HandlerMessage(MessageType type, object? data)
+    {
+        public MessageType Type { get; } = type;
+        public object? Data { get; } = data;
+    }
+
+    private sealed class CompositionHandler : CompositionCustomVisualHandler
+    {
+        public CompositionHandler(double minimum, double maximum, double value, bool isActive,
+            IBrush? background, IBrush? foreground)
+        {
+            _min = (float)minimum;
+            _max = (float)maximum;
+            _value = (float)value;
+            _active = isActive;
+
+            if (background is ISolidColorBrush scb)
+                _background = scb.Color.ToSKColor();
+
+            if (foreground is ISolidColorBrush scbF)
+                _foreground = scbF.Color.ToSKColor();
+
+            _paint = new SKPaint
+            {
+                IsAntialias = true,
+                IsStroke = true,
+                StrokeWidth = 4f,
+                StrokeCap = SKStrokeCap.Round
+            };
+
+            _path = new SKPath();
+        }
+
+        public override void OnRender(ImmediateDrawingContext drawingContext)
+        {
+            if (!_active) return;
+
+            var feat = drawingContext.TryGetFeature<ISkiaSharpApiLeaseFeature>();
+            if (feat is null) return;
+
+            using var lease = feat.Lease();
+            var canvas = lease.SkCanvas;
+
+            canvas.Save();
+            canvas.Scale((float)_scale, (float)_scale);
+
+            if (_background.HasValue)
+            {
+                _paint.Color = _background.Value;
+                canvas.DrawArc(VisualBounds, 0, 360, false, _paint);
+            }
+
+            _paint.Color = _foreground;
+            canvas.DrawPath(_path, _paint);
+
+            canvas.Restore();
+        }
+
+        public override void OnAnimationFrameUpdate()
+        {
+            Invalidate();
+            Update();
+
+            if (_active && (_indeterminate || _isAnimatingToValue))
+                RegisterForNextAnimationFrameUpdate();
+        }
+
+        private void Update()
+        {
+            if (_indeterminate)
+            {
+                var now = CompositionNow;
+                if (!_lastTime.HasValue) _lastTime = now;
+                var elapsed = now - _lastTime.Value;
+                var seconds = elapsed.TotalSeconds;
+
+                if (seconds > Duration)
+                {
+                    while (seconds > Duration) seconds -= Duration;
+                    _lastTime = now - TimeSpan.FromSeconds(seconds);
+                }
+
+                var progress = (float)(seconds / Duration);
+
+                float size;
+                if (progress < 0.25)
+                    size = 180 * (progress / 0.25f);
+                else if (progress >= 0.75)
+                    size = 180 * ((1 - progress) / 0.25f);
+                else
+                    size = 180;
+
+                var size2 = size / 2;
+                var position = 1080 * progress;
+
+                _path.Reset();
+                _path.MoveTo(40, 10);
+                _path.AddArc(VisualBounds, -90 + (position - size2), size);
+            }
+            else if (_isAnimatingToValue)
+            {
+                var now = CompositionNow;
+                if (!_lastTime.HasValue) _lastTime = now;
+                var elapsed = now - _lastTime.Value;
+                var seconds = elapsed.TotalSeconds;
+
+                var progress = (float)(seconds / Duration);
+                if (progress >= 1)
+                {
+                    _isAnimatingToValue = false;
+                    _lastTime = null;
+                    progress = 1;
+                }
+
+                var dV = _value - _lastValue;
+                var currentValue = _lastValue + (dV * progress);
+                _path.Reset();
+                _path.MoveTo(40, 10);
+                _path.AddArc(VisualBounds, -90, 360 * (currentValue - _min) / (_max - _min));
+            }
+            else
+            {
+                _path.Reset();
+                _path.MoveTo(40, 10);
+                _path.AddArc(VisualBounds, -90, 360 * (_value - _min) / (_max - _min));
+            }
+        }
+
+        public override void OnMessage(object message)
+        {
+            if (message is not HandlerMessage hm) return;
+
+            switch (hm.Type)
+            {
+                case MessageType.Min:
+                    _min = (float)hm.Data!;
+                    break;
+
+                case MessageType.Max:
+                    _max = (float)hm.Data!;
+                    break;
+
+                case MessageType.Value:
+                {
+                    var next = (float)hm.Data!;
+                    _lastValue = _value;
+                    if (next <= _value)
+                    {
+                        _value = next;
+                        _isAnimatingToValue = false;
+                    }
+                    else
+                    {
+                        _value = next;
+                        _isAnimatingToValue = true;
+                        RegisterForNextAnimationFrameUpdate();
+                        return;
+                    }
+                    break;
+                }
+
+                case MessageType.Active:
+                    _active = (bool)hm.Data!;
+                    if (_active && _indeterminate)
+                    {
+                        RegisterForNextAnimationFrameUpdate();
+                        return;
+                    }
+                    _lastTime = null;
+                    break;
+
+                case MessageType.Indeterminate:
+                    _indeterminate = (bool)hm.Data!;
+                    if (_indeterminate && _active)
+                    {
+                        RegisterForNextAnimationFrameUpdate();
+                        return;
+                    }
+                    _lastTime = null;
+                    break;
+
+                case MessageType.Background:
+                    _background = hm.Data is SKColor c ? c : null;
+                    break;
+
+                case MessageType.Foreground:
+                    _foreground = hm.Data is SKColor c2 ? c2 : SKColors.Transparent;
+                    break;
+
+                case MessageType.Scale:
+                    _scale = (double)hm.Data!;
+                    break;
+            }
+
+            Update();
+            Invalidate();
+        }
+
+        private TimeSpan? _lastTime;
+        private const float Duration = 2;
+        private readonly SKPaint _paint;
+        private readonly SKPath _path;
+        private static readonly SKRect VisualBounds = new(10, 10, 70, 70);
+
+        private SKColor? _background;
+        private SKColor _foreground;
+        private float _min, _max, _value;
+        private bool _indeterminate;
+        private bool _active;
+        private bool _isAnimatingToValue;
+        private float _lastValue;
+        private double _scale = 1;
+    }
+}

--- a/src/Zafiro.Avalonia/Controls/ProgressRing/ProgressRingStyles.axaml
+++ b/src/Zafiro.Avalonia/Controls/ProgressRing/ProgressRingStyles.axaml
@@ -1,0 +1,27 @@
+<ResourceDictionary xmlns="https://github.com/avaloniaui"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:controls="clr-namespace:Zafiro.Avalonia.Controls">
+
+    <ControlTheme TargetType="controls:ProgressRing"
+                  x:Key="{x:Type controls:ProgressRing}">
+        <Setter Property="Foreground" Value="{DynamicResource SystemAccentColor}" />
+        <Setter Property="Background" Value="Transparent" />
+        <Setter Property="IsHitTestVisible" Value="False" />
+        <Setter Property="HorizontalAlignment" Value="Center" />
+        <Setter Property="VerticalAlignment" Value="Center" />
+        <Setter Property="MinHeight" Value="16" />
+        <Setter Property="MinWidth" Value="16" />
+        <Setter Property="IsTabStop" Value="False" />
+        <Setter Property="Width" Value="32" />
+        <Setter Property="Height" Value="32" />
+        <Setter Property="Maximum" Value="100" />
+        <Setter Property="Template">
+            <ControlTemplate>
+                <Panel Background="Transparent">
+                    <controls:ProgressRingAnimatedVisual Name="AnimatedVisual" />
+                </Panel>
+            </ControlTemplate>
+        </Setter>
+    </ControlTheme>
+
+</ResourceDictionary>

--- a/src/Zafiro.Avalonia/Controls/ReactiveButton.axaml
+++ b/src/Zafiro.Avalonia/Controls/ReactiveButton.axaml
@@ -1,7 +1,7 @@
 <Styles xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:controls="clr-namespace:Zafiro.Avalonia.Controls"
-        xmlns:c="clr-namespace:FluentAvalonia.UI.Controls;assembly=FluentAvalonia"
+        xmlns:c="clr-namespace:Zafiro.Avalonia.Controls"
         xmlns:avalonia="clr-namespace:Zafiro.Avalonia"
         xmlns:panels="clr-namespace:Zafiro.Avalonia.Controls.Panels">
     <Styles.Resources>

--- a/src/Zafiro.Avalonia/Controls/ReactiveIconButton.axaml
+++ b/src/Zafiro.Avalonia/Controls/ReactiveIconButton.axaml
@@ -1,6 +1,6 @@
 <Styles xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        xmlns:c="clr-namespace:FluentAvalonia.UI.Controls;assembly=FluentAvalonia">
+        xmlns:c="clr-namespace:Zafiro.Avalonia.Controls">
 
     <Design.PreviewWith>
         <StackPanel>

--- a/src/Zafiro.Avalonia/Controls/SlimDataGrid/Column.cs
+++ b/src/Zafiro.Avalonia/Controls/SlimDataGrid/Column.cs
@@ -31,7 +31,7 @@ public class Column : AvaloniaObject
 
     [AssignBinding]
     [InheritDataTypeFromItems(nameof(SlimDataGrid.ItemsSource), AncestorType = typeof(SlimDataGrid))]
-    public IBinding? Binding { get; set; }
+    public BindingBase? Binding { get; set; }
 
     public object? Header { get; set; }
 

--- a/src/Zafiro.Avalonia/Controls/StatusBar/Jobs/TransientJob.axaml
+++ b/src/Zafiro.Avalonia/Controls/StatusBar/Jobs/TransientJob.axaml
@@ -5,7 +5,7 @@
              xmlns:designTime="clr-namespace:Zafiro.Avalonia.DesignTime;assembly=Zafiro.Avalonia"
              xmlns:jobs1="clr-namespace:Zafiro.Avalonia.Controls.StatusBar.Jobs"
              xmlns:design="clr-namespace:Zafiro.Avalonia.Controls.StatusBar.Design"
-             xmlns:controls="clr-namespace:FluentAvalonia.UI.Controls;assembly=FluentAvalonia"
+             xmlns:controls="clr-namespace:Zafiro.Avalonia.Controls"
              mc:Ignorable="d" d:DesignWidth="250" d:DesignHeight="30"
              x:Class="Zafiro.Avalonia.Controls.StatusBar.Jobs.TransientJob" x:DataType="jobs1:IJobViewModel">
 

--- a/src/Zafiro.Avalonia/Controls/StatusBar/StatusBarView.axaml
+++ b/src/Zafiro.Avalonia/Controls/StatusBar/StatusBarView.axaml
@@ -7,7 +7,7 @@
              xmlns:s="clr-namespace:Zafiro.Avalonia.Controls.StatusBar"
              xmlns:j="clr-namespace:Zafiro.Avalonia.Controls.StatusBar.Jobs"
              xmlns:design="clr-namespace:Zafiro.Avalonia.Controls.StatusBar.Design"
-             xmlns:controls="clr-namespace:FluentAvalonia.UI.Controls;assembly=FluentAvalonia"
+             xmlns:controls="clr-namespace:Zafiro.Avalonia.Controls"
              mc:Ignorable="d" d:DesignWidth="500"
              x:Class="Zafiro.Avalonia.Controls.StatusBar.StatusBarView" x:DataType="s:IStatusBar">
 

--- a/src/Zafiro.Avalonia/DesignTime/ReturnExtension.cs
+++ b/src/Zafiro.Avalonia/DesignTime/ReturnExtension.cs
@@ -1,7 +1,6 @@
 using System.ComponentModel;
 using System.Globalization;
 using System.Reflection;
-using Avalonia.Data.Core;
 using Avalonia.Markup.Xaml;
 using JetBrains.Annotations;
 
@@ -29,7 +28,16 @@ public class ReturnExtension : MarkupExtension
         }
 
         var service = (IProvideValueTarget)serviceProvider.GetService(typeof(IProvideValueTarget))!;
-        var type = ((ClrPropertyInfo) service.TargetProperty).PropertyType.GenericTypeArguments[0];
+
+        Type propertyType = service.TargetProperty switch
+        {
+            AvaloniaProperty ap => ap.PropertyType,
+            PropertyInfo pi => pi.PropertyType,
+            _ => throw new InvalidOperationException(
+                $"Cannot determine property type from {service.TargetProperty?.GetType()}")
+        };
+
+        var type = propertyType.GenericTypeArguments[0];
         Type observableType = typeof(System.Reactive.Linq.Observable);
         MethodInfo returnMethodInfo = observableType.GetMethods().First(x => x.Name == "Return" && x.GetParameters().Length == 1);
         var method = returnMethodInfo.MakeGenericMethod(type);

--- a/src/Zafiro.Avalonia/GraphWizard/View/GraphWizardFooterView.axaml
+++ b/src/Zafiro.Avalonia/GraphWizard/View/GraphWizardFooterView.axaml
@@ -11,7 +11,7 @@
     </Design.PreviewWith>
 
     <ControlTheme x:Key="{x:Type view:GraphWizardFooterView}" TargetType="view:GraphWizardFooterView">
-        <Setter Property="Wizard" Value="{Binding Wizard}" />
+        <Setter Property="Wizard" Value="{ReflectionBinding Wizard}" />
         <Setter Property="Template">
             <ControlTemplate>
                 <Border Padding="10" Background="{DynamicResource SystemChromeMediumColor}">

--- a/src/Zafiro.Avalonia/GraphWizard/View/GraphWizardHeaderView.axaml
+++ b/src/Zafiro.Avalonia/GraphWizard/View/GraphWizardHeaderView.axaml
@@ -11,7 +11,7 @@
     </Design.PreviewWith>
 
     <ControlTheme x:Key="{x:Type view:GraphWizardHeaderView}" TargetType="view:GraphWizardHeaderView">
-        <Setter Property="Wizard" Value="{Binding Wizard}" />
+        <Setter Property="Wizard" Value="{ReflectionBinding Wizard}" />
         <Setter Property="Background" Value="{DynamicResource SystemChromeLowColor}" />
         <Setter Property="Padding" Value="10" />
         <Setter Property="Template">

--- a/src/Zafiro.Avalonia/Styles.axaml
+++ b/src/Zafiro.Avalonia/Styles.axaml
@@ -16,8 +16,7 @@
                 <ResourceInclude Source="Controls/TypewriterTextControl.axaml" />
                 <ResourceInclude Source="Controls/CircularProgressBar.axaml" />
                 <ResourceInclude Source="Icons.axaml" />
-                <ResourceInclude
-                    Source="avares://FluentAvalonia/Styling/ControlThemes/FAControls/ProgressRingStyles.axaml" />
+                <ResourceInclude Source="Controls/ProgressRing/ProgressRingStyles.axaml" />
                 <ResourceInclude Source="GraphWizard/View/GraphWizardHeaderView.axaml" />
                 <ResourceInclude Source="GraphWizard/View/GraphWizardFooterView.axaml" />
             </ResourceDictionary.MergedDictionaries>

--- a/src/Zafiro.Avalonia/Styles/Loading.axaml
+++ b/src/Zafiro.Avalonia/Styles/Loading.axaml
@@ -1,6 +1,6 @@
 <Styles xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        xmlns:c="clr-namespace:FluentAvalonia.UI.Controls;assembly=FluentAvalonia">
+        xmlns:c="clr-namespace:Zafiro.Avalonia.Controls">
 
     <Styles.Resources>
         <ControlTheme x:Key="LoadingCover" TargetType="{x:Type Loading}">

--- a/src/Zafiro.Avalonia/Zafiro.Avalonia.csproj
+++ b/src/Zafiro.Avalonia/Zafiro.Avalonia.csproj
@@ -11,8 +11,9 @@
     <ItemGroup>
         <PackageReference Include="Avalonia"/>
         <PackageReference Include="Avalonia.Controls.DataGrid"/>
+        <PackageReference Include="Avalonia.Skia"/>
         <PackageReference Include="CSharpFunctionalExtensions"/>
-        <PackageReference Include="FluentAvaloniaUI"/>
+
         <PackageReference Include="JetBrains.Annotations"/>
         <PackageReference Include="ReactiveProperty"/>
         <PackageReference Include="ReactiveUI.Avalonia"/>

--- a/test/Zafiro.Avalonia.Tests/FlexPanelTests.cs
+++ b/test/Zafiro.Avalonia.Tests/FlexPanelTests.cs
@@ -217,6 +217,26 @@ public class FlexPanelTests
     }
 
     [AvaloniaFact]
+    public void Should_justify_end_on_each_wrapped_line()
+    {
+        // 3 items of 40px each, gap 10, container 100px wide
+        // Row 1: items 1+2 = 40+10+40 = 90, remaining = 10 → both start at x=10
+        // Row 2: item 3 = 40, remaining = 60 → starts at x=60
+        var first = Item(width: 40, height: 20);
+        var second = Item(width: 40, height: 20);
+        var third = Item(width: 40, height: 20);
+
+        var panel = Panel(FlexDirection.Row, FlexWrap.Wrap, FlexJustify.End, FlexAlign.Start, 10, first, second, third);
+        panel.AlignContent = FlexAlignContent.Start;
+
+        ShowAndLayout(panel, 100, 100);
+
+        AssertBounds(first, x: 10, y: 0, width: 40, height: 20);
+        AssertBounds(second, x: 60, y: 0, width: 40, height: 20);
+        AssertBounds(third, x: 60, y: 30, width: 40, height: 20);
+    }
+
+    [AvaloniaFact]
     public void Should_stretch_lines_on_cross_axis_by_default_when_wrapping()
     {
         var first = Item(width: 40, height: 20);

--- a/test/Zafiro.Avalonia.Tests/Zafiro.Avalonia.Tests.csproj
+++ b/test/Zafiro.Avalonia.Tests/Zafiro.Avalonia.Tests.csproj
@@ -17,7 +17,7 @@
         </PackageReference>
         <PackageReference Include="Microsoft.CodeAnalysis.CSharp"/>
         <PackageReference Include="Microsoft.NET.Test.Sdk" />
-        <PackageReference Include="xunit" />
+        <PackageReference Include="xunit.v3" />
         <PackageReference Include="xunit.runner.visualstudio" />
     </ItemGroup>
 


### PR DESCRIPTION
## Migrate to Avalonia 12

### Package updates
- Avalonia `11.3.12` → `12.0.0`
- Xaml.Behaviors.Avalonia `11.3.8.2` → `12.0.0`
- Svg.Controls.Skia.Avalonia `11.3.9.2` → `12.0.0`
- xunit `2.5.3` → xunit.v3 `3.2.2` (required by Avalonia.Headless.XUnit 12)

### Breaking changes fixed
- `IBinding` → `BindingBase` (SlimDataGrid/Column.cs)
- `ClrPropertyInfo` → `AvaloniaProperty`/`PropertyInfo` pattern matching (ReturnExtension.cs)
- `GetVisualRoot()` → `IsAttachedToVisualTree()` (UntouchedClassBehavior)
- `IClipboard.SetTextAsync`/`GetTextAsync` → extension methods + `TryGetTextAsync`
- `MathUtilities.GreaterThan` (now internal) → local helper (SmartWrapPanel)
- Compiled bindings default → `ReflectionBinding` where `x:DataType` unavailable

### FluentAvaloniaUI removed
- Ported `ProgressRing` control (MIT) into `Zafiro.Avalonia.Controls`
- Supports both indeterminate and determinate modes
- Uses `CompositionCustomVisualHandler` + SkiaSharp rendering

### Projects temporarily excluded from solution
- `Zafiro.Avalonia.DataViz` — blocked by PanAndZoom (no Av12 release)
- `Zafiro.Avalonia.Icons.Projektanker` — blocked by Projektanker.Icons.Avalonia (no Av12 release)
- `TestApp` / `TestApp.Desktop` — reference blocked projects

### Removed unused packages
- `Deadpikle.AvaloniaProgressRing`
- `Avalonia.Controls.PanAndZoom`

### Tests
150/152 passing (2 pre-existing flaky timeouts in SlimWizardScenarioTests)