### PR TITLE
feat: Upgrade to .NET 10

### DIFF
--- a/src/Zafiro.Avalonia.Dialogs/Zafiro.Avalonia.Dialogs.csproj
+++ b/src/Zafiro.Avalonia.Dialogs/Zafiro.Avalonia.Dialogs.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
     </PropertyGroup>

--- a/src/Zafiro.Avalonia.Icons.Svg/Zafiro.Avalonia.Icons.Svg.csproj
+++ b/src/Zafiro.Avalonia.Icons.Svg/Zafiro.Avalonia.Icons.Svg.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
     </PropertyGroup>

--- a/src/Zafiro.Avalonia/Zafiro.Avalonia.csproj
+++ b/src/Zafiro.Avalonia/Zafiro.Avalonia.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <!-- Enable writing source generator outputs to disk for inspection -->
@@ -17,7 +17,6 @@
         <PackageReference Include="JetBrains.Annotations"/>
         <PackageReference Include="ReactiveProperty"/>
         <PackageReference Include="ReactiveUI.Avalonia"/>
-        <PackageReference Include="System.Linq.Async"/>
         <PackageReference Include="Xaml.Behaviors.Avalonia"/>
         <PackageReference Include="ReactiveUI.SourceGenerators">
             <PrivateAssets>all</PrivateAssets>

--- a/test/Zafiro.Avalonia.Tests/Zafiro.Avalonia.Tests.csproj
+++ b/test/Zafiro.Avalonia.Tests/Zafiro.Avalonia.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
 


### PR DESCRIPTION
## Upgrade to .NET 10

- Update TFM from `net8.0` to `net10.0` in core libraries and tests
- Remove `System.Linq.Async` package (now built into .NET 10 BCL as `System.Linq.AsyncEnumerable`)
- `Zafiro.Avalonia.Generators` stays on `netstandard2.0` (Roslyn source generator requirement)

### Tests
150/152 passing (same 2 pre-existing flaky timeouts)