### PR TITLE
refactor: use Func<IStorageProvider> factory in AvaloniaFileSystemPicker

### DIFF
--- a/docs/ai/conventions.md
+++ b/docs/ai/conventions.md
@@ -180,7 +180,7 @@ services.AddTransient<MainViewModel>();
 
 // 6. Platform services
 services.AddSingleton<IFileSystemPicker>(_ =>
-    new AvaloniaFileSystemPicker(TopLevel.GetTopLevel(view).StorageProvider));
+    new AvaloniaFileSystemPicker(() => TopLevel.GetTopLevel(view)!.StorageProvider));
 
 var provider = services.BuildServiceProvider();
 ```

--- a/samples/TestApp/TestApp/CompositionRoot.cs
+++ b/samples/TestApp/TestApp/CompositionRoot.cs
@@ -39,7 +39,7 @@ public static class CompositionRoot
         services.AddTransient<MainViewModel>();
         services.AddTransient<TargetViewModel>();
         services.AddSingleton<IFileSystemPicker>(_ =>
-            new AvaloniaFileSystemPicker(TopLevel.GetTopLevel(view).StorageProvider));
+            new AvaloniaFileSystemPicker(() => TopLevel.GetTopLevel(view)!.StorageProvider));
 
         // Build sample cards from [Section]/[SectionGroup] attributes.
         var cards = BuildSampleCards();

--- a/src/Zafiro.Avalonia/Storage/AvaloniaFileSystemPicker.cs
+++ b/src/Zafiro.Avalonia/Storage/AvaloniaFileSystemPicker.cs
@@ -1,3 +1,4 @@
+using System;
 using Avalonia.Platform.Storage;
 using CSharpFunctionalExtensions;
 using JetBrains.Annotations;
@@ -8,7 +9,7 @@ using Zafiro.FileSystem.Mutable;
 namespace Zafiro.Avalonia.Storage;
 
 [PublicAPI]
-public class AvaloniaFileSystemPicker(IStorageProvider storageProvider) : IFileSystemPicker
+public class AvaloniaFileSystemPicker(Func<IStorageProvider> storageProviderFactory) : IFileSystemPicker
 {
     public Task<Result<IEnumerable<INamedByteSource>>> PickForOpenMultiple(params FileTypeFilter[] filters)
     {
@@ -32,7 +33,7 @@ public class AvaloniaFileSystemPicker(IStorageProvider storageProvider) : IFileS
         Maybe<string> defaultExtension,
         params FileTypeFilter[] filters)
     {
-        var file = await storageProvider.SaveFilePickerAsync(new FilePickerSaveOptions
+        var file = await storageProviderFactory().SaveFilePickerAsync(new FilePickerSaveOptions
         {
             FileTypeChoices = FilePicker.Map(filters),
             DefaultExtension = defaultExtension.GetValueOrDefault(),
@@ -49,7 +50,7 @@ public class AvaloniaFileSystemPicker(IStorageProvider storageProvider) : IFileS
 
     private Task<Result<IEnumerable<INamedByteSource>>> PickCore(FilePickerOpenOptions filePickerOpenOptions)
     {
-        return Result.Try(async () => (await storageProvider.OpenFilePickerAsync(filePickerOpenOptions)).AsEnumerable())
+        return Result.Try(async () => (await storageProviderFactory().OpenFilePickerAsync(filePickerOpenOptions)).AsEnumerable())
             .MapEach(storageFile => new MutableStorageFile(storageFile))
             .MapEach(x => x.AsReadOnly())
             .Combine();
@@ -59,7 +60,7 @@ public class AvaloniaFileSystemPicker(IStorageProvider storageProvider) : IFileS
         FolderPickerOpenOptions folderPickerOpenOptions)
     {
         var openFolderPickerAsync =
-            await storageProvider.OpenFolderPickerAsync(folderPickerOpenOptions).ConfigureAwait(false);
+            await storageProviderFactory().OpenFolderPickerAsync(folderPickerOpenOptions).ConfigureAwait(false);
         return Maybe.From(openFolderPickerAsync.AsEnumerable())
             .MapEach(IMutableDirectory (x) => new StorageDirectory(x));
     }


### PR DESCRIPTION
## Summary

Replace direct `IStorageProvider` dependency with a `Func<IStorageProvider>` factory in `AvaloniaFileSystemPicker` so the provider is resolved lazily at call time instead of requiring it at DI registration, when `TopLevel` may not yet be available.

## Changes

- **`AvaloniaFileSystemPicker.cs`**: Constructor now takes `Func<IStorageProvider>` instead of `IStorageProvider`. Each method invokes the factory when needed.
- **`CompositionRoot.cs`**: Updated DI registration to pass a factory lambda.
- **`docs/ai/conventions.md`**: Updated DI registration example.

Closes #215 +semver:minor