### PR TITLE
Update ReactiveUI ecosystem and DiagnosticsSupport for Avalonia 12

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -16,10 +16,10 @@
       <PackageVersion Include="Avalonia.iOS" Version="$(AvaloniaVersion)"/>
       <PackageVersion Include="Avalonia.Skia" Version="$(AvaloniaVersion)"/>
       <PackageVersion Include="Avalonia.Themes.Fluent" Version="$(AvaloniaVersion)"/>
-      <PackageVersion Include="AvaloniaUI.DiagnosticsSupport" Version="2.2.0-beta3"/>
+      <PackageVersion Include="AvaloniaUI.DiagnosticsSupport" Version="2.2.0"/>
 
       <!-- Avalonia 12 ecosystem -->
-      <PackageVersion Include="ReactiveUI.Avalonia" Version="11.3.8"/>
+      <PackageVersion Include="ReactiveUI.Avalonia" Version="11.4.12"/>
       <PackageVersion Include="Svg.Controls.Skia.Avalonia" Version="12.0.0"/>
       <PackageVersion Include="Xaml.Behaviors.Avalonia" Version="12.0.0"/>
       <PackageVersion Include="Xaml.Behaviors.Interactions.DragAndDrop" Version="12.0.0"/>
@@ -34,9 +34,9 @@
 
       <!-- ReactiveUI -->
       <PackageVersion Include="ReactiveProperty" Version="9.8.0"/>
-      <PackageVersion Include="ReactiveUI" Version="22.2.1"/>
-      <PackageVersion Include="ReactiveUI.SourceGenerators" Version="2.5.1"/>
-      <PackageVersion Include="ReactiveUI.Validation" Version="6.0.5"/>
+      <PackageVersion Include="ReactiveUI" Version="23.1.8"/>
+      <PackageVersion Include="ReactiveUI.SourceGenerators" Version="2.6.1"/>
+      <PackageVersion Include="ReactiveUI.Validation" Version="7.0.5"/>
 
       <!-- Infrastructure -->
       <PackageVersion Include="coverlet.collector" Version="6.0.4"/>

--- a/samples/FileExplorer/SampleFileExplorer/Program.cs
+++ b/samples/FileExplorer/SampleFileExplorer/Program.cs
@@ -1,6 +1,6 @@
 using System;
 using Avalonia;
-using Avalonia.ReactiveUI;
+using ReactiveUI.Avalonia;
 
 namespace SampleFileExplorer;
 
@@ -19,5 +19,5 @@ sealed class Program
             .UsePlatformDetect()
             .WithInterFont()
             .LogToTrace()
-            .UseReactiveUI();
+            .UseReactiveUI(_ => { });
 }

--- a/samples/FileExplorer/SampleFileExplorer/SampleFileExplorer.csproj
+++ b/samples/FileExplorer/SampleFileExplorer/SampleFileExplorer.csproj
@@ -8,7 +8,7 @@
     </PropertyGroup>
     
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <Nullable>enable</Nullable>
         <BuiltInComInteropSupport>true</BuiltInComInteropSupport>
         <ApplicationManifest>app.manifest</ApplicationManifest>

--- a/samples/FileExplorer/SampleFileExplorer/ViewModels/TestViewModel.cs
+++ b/samples/FileExplorer/SampleFileExplorer/ViewModels/TestViewModel.cs
@@ -1,3 +1,4 @@
+using ReactiveUI.Avalonia;
 using System;
 using System.Reactive;
 using System.Reactive.Linq;
@@ -27,7 +28,7 @@ public class TestViewModel
                 .Map(data => new CopyFileAction(data, b))
                 .Bind(async fileAction =>
                 {
-                    using (fileAction.Progress.Select(x => x.Value).Sample(TimeSpan.FromSeconds(1), RxApp.MainThreadScheduler).Subscribe(progressSubject))
+                    using (fileAction.Progress.Select(x => x.Value).Sample(TimeSpan.FromSeconds(1), AvaloniaScheduler.Instance).Subscribe(progressSubject))
                     {
                         return await fileAction.Execute().ConfigureAwait(false);
                     }

--- a/samples/MinimalShell/MinimalShell.csproj
+++ b/samples/MinimalShell/MinimalShell.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <OutputType>WinExe</OutputType>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <Nullable>enable</Nullable>
         <LangVersion>latest</LangVersion>
         <ImplicitUsings>enable</ImplicitUsings>

--- a/samples/MinimalShell/Program.cs
+++ b/samples/MinimalShell/Program.cs
@@ -17,5 +17,5 @@ class Program
 #if DEBUG
             .WithDeveloperTools()
 #endif
-            .UseReactiveUI();
+            .UseReactiveUI(_ => { });
 }

--- a/samples/TestApp/TestApp.Android/MainActivity.cs
+++ b/samples/TestApp/TestApp.Android/MainActivity.cs
@@ -18,7 +18,7 @@ public class MainActivity : AvaloniaMainActivity<App>
     {
         var b = base.CustomizeAppBuilder(builder)
             .WithInterFont()
-            .UseReactiveUI();
+            .UseReactiveUI(_ => { });
         return b;
     }
 }

--- a/samples/TestApp/TestApp.Browser/Program.cs
+++ b/samples/TestApp/TestApp.Browser/Program.cs
@@ -12,7 +12,7 @@ internal partial class Program
 {
     private static async Task Main(string[] args) => await BuildAvaloniaApp()
         .WithInterFont()
-        .UseReactiveUI()
+        .UseReactiveUI(_ => { })
         .StartBrowserAppAsync("out");
 
     public static AppBuilder BuildAvaloniaApp()

--- a/samples/TestApp/TestApp.Desktop/Program.cs
+++ b/samples/TestApp/TestApp.Desktop/Program.cs
@@ -18,5 +18,5 @@ class Program
         => AppBuilder.Configure<App>()
             .UsePlatformDetect()
             .WithInterFont()
-            .UseReactiveUI();
+            .UseReactiveUI(_ => { });
 }

--- a/samples/TestApp/TestApp.Desktop/TestApp.Desktop.csproj
+++ b/samples/TestApp/TestApp.Desktop/TestApp.Desktop.csproj
@@ -3,7 +3,7 @@
         <OutputType>WinExe</OutputType>
         <!--If you are willing to use Windows/MacOS native APIs you will need to create 3 projects.
         One for Windows with net7.0-windows TFM, one for MacOS with net7.0-macos and one with net7.0 TFM for Linux.-->
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <RollForward>LatestMajor</RollForward>
     </PropertyGroup>
     <PropertyGroup>
@@ -15,6 +15,7 @@
     </ItemGroup>
     <ItemGroup>
         <PackageReference Include="Avalonia.Desktop"/>
+        <PackageReference Include="ReactiveUI.Avalonia"/>
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="../TestApp/TestApp.csproj"/>

--- a/samples/TestApp/TestApp.iOS/AppDelegate.cs
+++ b/samples/TestApp/TestApp.iOS/AppDelegate.cs
@@ -4,7 +4,7 @@ using Avalonia;
 using Avalonia.Controls;
 using Avalonia.iOS;
 using Avalonia.Media;
-using Avalonia.ReactiveUI;
+using ReactiveUI.Avalonia;
 
 namespace TestApp.iOS;
 
@@ -18,6 +18,6 @@ public partial class AppDelegate : AvaloniaAppDelegate<App>
     {
         return base.CustomizeAppBuilder(builder)
             .WithInterFont()
-            .UseReactiveUI();
+            .UseReactiveUI(_ => { });
     }
 }

--- a/samples/TestApp/TestApp/CompositionRoot.cs
+++ b/samples/TestApp/TestApp/CompositionRoot.cs
@@ -1,3 +1,4 @@
+using ReactiveUI;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -49,7 +50,7 @@ public static class CompositionRoot
 
         // Register INavigator as singleton (the hub uses a single navigator for the whole app).
         services.AddSingleton<INavigator>(sp =>
-            new Navigator(sp, ((ILogger)logger).AsMaybe(), RxApp.MainThreadScheduler));
+            new Navigator(sp, ((ILogger)logger).AsMaybe(), RxSchedulers.MainThreadScheduler));
 
         var serviceProvider = services.BuildServiceProvider();
 

--- a/samples/TestApp/TestApp/Samples/HomeViewModel.cs
+++ b/samples/TestApp/TestApp/Samples/HomeViewModel.cs
@@ -1,3 +1,4 @@
+using ReactiveUI;
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
@@ -27,7 +28,7 @@ public partial class HomeViewModel : ReactiveObject
             .ToList();
 
         var searchFilter = this.WhenAnyValue(x => x.State.SearchText)
-            .Throttle(TimeSpan.FromMilliseconds(300), RxApp.MainThreadScheduler)
+            .Throttle(TimeSpan.FromMilliseconds(300), RxSchedulers.MainThreadScheduler)
             .Select(BuildSearchFilter);
 
         var categoryFilter = this.WhenAnyValue(x => x.State.SelectedCategory)

--- a/samples/TestApp/TestApp/Samples/Misc/EasyListBoxViewModel.cs
+++ b/samples/TestApp/TestApp/Samples/Misc/EasyListBoxViewModel.cs
@@ -1,3 +1,4 @@
+using ReactiveUI;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -35,7 +36,7 @@ public class EasyListBoxViewModel
         MutableGraph = graph2D;
 
         Play = ReactiveCommand
-            .CreateFromObservable(() => Observable.Interval(TimeSpan.FromMilliseconds(12), RxApp.MainThreadScheduler).Do(_ => engine1.Step()));
+            .CreateFromObservable(() => Observable.Interval(TimeSpan.FromMilliseconds(12), RxSchedulers.MainThreadScheduler).Do(_ => engine1.Step()));
 
         Play.Execute().Subscribe();
 

--- a/samples/TestApp/TestApp/Samples/Misc/GradualGraphViewModel.cs
+++ b/samples/TestApp/TestApp/Samples/Misc/GradualGraphViewModel.cs
@@ -1,3 +1,4 @@
+using ReactiveUI;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -32,7 +33,7 @@ public class GradualGraphViewModel
         MutableGraph = graph2D;
 
         Play = ReactiveCommand
-            .CreateFromObservable(() => Observable.Interval(TimeSpan.FromMilliseconds(12), RxApp.MainThreadScheduler).Do(_ => engine1.Step()));
+            .CreateFromObservable(() => Observable.Interval(TimeSpan.FromMilliseconds(12), RxSchedulers.MainThreadScheduler).Do(_ => engine1.Step()));
 
         Play.Execute().Subscribe();
 

--- a/samples/TestApp/TestApp/Samples/Misc/GraphViewModel.cs
+++ b/samples/TestApp/TestApp/Samples/Misc/GraphViewModel.cs
@@ -1,3 +1,4 @@
+using ReactiveUI;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -32,7 +33,7 @@ public class GraphViewModel
         MutableGraph = graph2D;
 
         Play = ReactiveCommand
-            .CreateFromObservable(() => Observable.Interval(TimeSpan.FromMilliseconds(12), RxApp.MainThreadScheduler).Do(_ => engine1.Step()));
+            .CreateFromObservable(() => Observable.Interval(TimeSpan.FromMilliseconds(12), RxSchedulers.MainThreadScheduler).Do(_ => engine1.Step()));
 
         Play.Execute().Subscribe();
 

--- a/samples/TestApp/TestApp/TestApp.csproj
+++ b/samples/TestApp/TestApp/TestApp.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <Nullable>enable</Nullable>
         <LangVersion>latest</LangVersion>
         <AvaloniaUseCompiledBindingsByDefault>true</AvaloniaUseCompiledBindingsByDefault>

--- a/src/Zafiro.Avalonia.DataViz/Zafiro.Avalonia.DataViz.csproj
+++ b/src/Zafiro.Avalonia.DataViz/Zafiro.Avalonia.DataViz.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <Nullable>enable</Nullable>
         <LangVersion>latest</LangVersion>
         <AvaloniaUseCompiledBindingsByDefault>true</AvaloniaUseCompiledBindingsByDefault>

--- a/src/Zafiro.Avalonia.Generators/SectionsRegistrationGenerator.cs
+++ b/src/Zafiro.Avalonia.Generators/SectionsRegistrationGenerator.cs
@@ -102,7 +102,7 @@ public sealed class SectionsRegistrationGenerator : IIncrementalGenerator
             }
 
             sb.AppendLine(
-                "        }, logger: logger, scheduler: scheduler ?? global::ReactiveUI.RxApp.MainThreadScheduler);");
+                "        }, logger: logger, scheduler: scheduler ?? global::ReactiveUI.RxSchedulers.MainThreadScheduler);");
             sb.AppendLine("        return services;");
             sb.AppendLine("    }");
             sb.AppendLine();

--- a/src/Zafiro.Avalonia/Behaviors/ProgressBarExecutionBehavior.cs
+++ b/src/Zafiro.Avalonia/Behaviors/ProgressBarExecutionBehavior.cs
@@ -30,7 +30,7 @@ public class ProgressBarExecutionBehavior : DisposingBehavior<ProgressBar>
             .DisposeWith(disposable);
 
         this.WhenAnyObservable(x => x.Execution.Progress)
-            .ObserveOn(RxApp.MainThreadScheduler)
+            .ObserveOn(RxSchedulers.MainThreadScheduler)
             .Do(progress =>
             {
                 if (progress is NotStarted)

--- a/src/Zafiro.Avalonia/Behaviors/TextBoxAutoSelectTextBehavior.cs
+++ b/src/Zafiro.Avalonia/Behaviors/TextBoxAutoSelectTextBehavior.cs
@@ -23,7 +23,7 @@ public class TextBoxAutoSelectTextBehavior : AttachedToVisualTreeBehavior<TextBo
         return isFocused
             .Throttle(TimeSpan.FromSeconds(0.1))
             .DistinctUntilChanged()
-            .ObserveOn(RxApp.MainThreadScheduler)
+            .ObserveOn(RxSchedulers.MainThreadScheduler)
             .Where(focused => focused)
             .Do(_ => AssociatedObject.SelectAll())
             .Subscribe();

--- a/src/Zafiro.Avalonia/Behaviors/TypewriterBehavior.cs
+++ b/src/Zafiro.Avalonia/Behaviors/TypewriterBehavior.cs
@@ -17,7 +17,7 @@ public class TypewriterBehavior : DisposingBehavior<TextBlock>
     {
         return this.WhenAnyValue(x => x.TextToType)
             .WhereNotNull()
-            .Throttle(TimeSpan.FromSeconds(1), RxApp.MainThreadScheduler)
+            .Throttle(TimeSpan.FromSeconds(1), RxSchedulers.MainThreadScheduler)
             .Select(s => Remove(AssociatedObject.Text).Concat(Add(TextToType)))
             .Switch()
             .Do(text => AssociatedObject.Text = text)

--- a/src/Zafiro.Avalonia/Controls/EnhancedButton.axaml.cs
+++ b/src/Zafiro.Avalonia/Controls/EnhancedButton.axaml.cs
@@ -93,7 +93,7 @@ public class EnhancedButton : Button
         .Select(ObserveExecution)
         .Switch()
         .DistinctUntilChanged()
-        .ObserveOn(RxApp.MainThreadScheduler);
+        .ObserveOn(RxSchedulers.MainThreadScheduler);
 
     static IObservable<bool> ObserveExecution(ICommand? command) =>
         Maybe.From(command)

--- a/src/Zafiro.Avalonia/SectionRegistrationRegistry.cs
+++ b/src/Zafiro.Avalonia/SectionRegistrationRegistry.cs
@@ -28,7 +28,7 @@ public static class SectionRegistrationRegistry
 
     public static IServiceCollection AddAllSectionsFromRegistry(this IServiceCollection services, ILogger? logger = null, IScheduler? scheduler = null)
     {
-        scheduler ??= RxApp.MainThreadScheduler;
+        scheduler ??= RxSchedulers.MainThreadScheduler;
 
         Registration[] snapshot;
         lock (Sync)

--- a/test/Zafiro.Avalonia.Graphs.Tests/Zafiro.Avalonia.DataViz.Tests.csproj
+++ b/test/Zafiro.Avalonia.Graphs.Tests/Zafiro.Avalonia.DataViz.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 


### PR DESCRIPTION
Update all ReactiveUI packages and DiagnosticsSupport to their latest stable versions compatible with Avalonia 12.

### Package updates
| Package | Before | After |
|---|---|---|
| ReactiveUI | 22.2.1 | **23.1.8** |
| ReactiveUI.Avalonia | 11.3.8 | **11.4.12** |
| ReactiveUI.SourceGenerators | 2.5.1 | **2.6.1** |
| ReactiveUI.Validation | 6.0.5 | **7.0.5** |
| AvaloniaUI.DiagnosticsSupport | 2.2.0-beta3 | **2.2.0** (stable) |

### Breaking changes addressed
- `RxApp.MainThreadScheduler` → `RxSchedulers.MainThreadScheduler` (ReactiveUI 23.x rename)
- Namespace `Avalonia.ReactiveUI` → `ReactiveUI.Avalonia` (ReactiveUI.Avalonia 11.4.x)
- `UseReactiveUI()` → `UseReactiveUI(_ => { })` (now requires `Action<ReactiveUIBuilder>`)
- Added `ReactiveUI.Avalonia` PackageReference to `TestApp.Desktop`
- Updated remaining `net8.0` projects to `net10.0`