### PR TITLE
Replace category button strip with pill-selector ListBox in TestApp

### DIFF
--- a/samples/TestApp/TestApp/Samples/HomeView.axaml
+++ b/samples/TestApp/TestApp/Samples/HomeView.axaml
@@ -32,30 +32,21 @@
                      HorizontalContentAlignment="Center" />
         </StackPanel>
 
-        <!-- Category Chips -->
-        <ScrollViewer DockPanel.Dock="Top" HorizontalScrollBarVisibility="Auto"
-                      VerticalScrollBarVisibility="Disabled" Margin="32,12,32,0">
-            <StackPanel Orientation="Horizontal" Spacing="8" HorizontalAlignment="Center">
-                <EnhancedButton Content="All"
-                                Command="{Binding ClearCategory}"
-                                Classes="Ghost" />
-                <ItemsControl ItemsSource="{Binding Categories}">
-                    <ItemsControl.ItemsPanel>
-                        <ItemsPanelTemplate>
-                            <StackPanel Orientation="Horizontal" Spacing="8" />
-                        </ItemsPanelTemplate>
-                    </ItemsControl.ItemsPanel>
-                    <ItemsControl.ItemTemplate>
-                        <DataTemplate x:DataType="x:String">
-                            <EnhancedButton Content="{Binding}"
-                                            Command="{Binding $parent[UserControl].((samples:HomeViewModel)DataContext).SelectCategory}"
-                                            CommandParameter="{Binding}"
-                                            Classes="Ghost" />
-                        </DataTemplate>
-                    </ItemsControl.ItemTemplate>
-                </ItemsControl>
-            </StackPanel>
-        </ScrollViewer>
+        <!-- Category Pills -->
+        <ListBox DockPanel.Dock="Top"
+                 ItemsSource="{Binding Categories}"
+                 SelectedItem="{Binding State.SelectedCategory}"
+                 Classes="PillSelector"
+                 HorizontalAlignment="Center"
+                 Margin="32,12,32,0"
+                 ScrollViewer.HorizontalScrollBarVisibility="Disabled"
+                 ScrollViewer.VerticalScrollBarVisibility="Disabled">
+            <ListBox.ItemsPanel>
+                <ItemsPanelTemplate>
+                    <WrapPanel Orientation="Horizontal" />
+                </ItemsPanelTemplate>
+            </ListBox.ItemsPanel>
+        </ListBox>
 
         <!-- Card Grid -->
         <ScrollViewer Margin="24,16,24,24">

--- a/samples/TestApp/TestApp/Samples/HomeViewModel.cs
+++ b/samples/TestApp/TestApp/Samples/HomeViewModel.cs
@@ -21,10 +21,8 @@ public partial class HomeViewModel : ReactiveObject
         State = state;
         allSamples.AddOrUpdate(samples);
 
-        Categories = samples
-            .Select(s => s.Category)
-            .Distinct()
-            .OrderBy(c => c)
+        Categories = new[] { "All" }
+            .Concat(samples.Select(s => s.Category).Distinct().OrderBy(c => c))
             .ToList();
 
         var searchFilter = this.WhenAnyValue(x => x.State.SearchText)
@@ -45,9 +43,6 @@ public partial class HomeViewModel : ReactiveObject
             .Subscribe();
 
         NavigateToSample = ReactiveCommand.CreateFromTask<SampleCard>(async card => { await navigator.Go(card.ViewModelType); });
-
-        SelectCategory = ReactiveCommand.Create<string>(category => { State.SelectedCategory = category; });
-        ClearCategory = ReactiveCommand.Create(() => { State.SelectedCategory = null; });
     }
 
     public HomeViewState State { get; }
@@ -55,8 +50,6 @@ public partial class HomeViewModel : ReactiveObject
     public ReadOnlyObservableCollection<SampleCard> FilteredSamples => filteredSamples;
     public IReadOnlyList<string> Categories { get; }
     public ReactiveCommand<SampleCard, Unit> NavigateToSample { get; }
-    public ReactiveCommand<string, Unit> SelectCategory { get; }
-    public ReactiveCommand<Unit, Unit> ClearCategory { get; }
 
     private static Func<SampleCard, bool> BuildSearchFilter(string? text)
     {
@@ -71,7 +64,7 @@ public partial class HomeViewModel : ReactiveObject
 
     private static Func<SampleCard, bool> BuildCategoryFilter(string? category)
     {
-        if (string.IsNullOrWhiteSpace(category))
+        if (string.IsNullOrWhiteSpace(category) || string.Equals(category, "All", StringComparison.OrdinalIgnoreCase))
         {
             return _ => true;
         }

--- a/samples/TestApp/TestApp/Samples/HomeViewState.cs
+++ b/samples/TestApp/TestApp/Samples/HomeViewState.cs
@@ -11,7 +11,7 @@ public partial class HomeViewState : ReactiveObject
 {
     [Reactive] private bool isDarkTheme;
     [Reactive] private string? searchText;
-    [Reactive] private string? selectedCategory;
+    [Reactive] private string? selectedCategory = "All";
 
     public HomeViewState()
     {

--- a/samples/TestApp/TestApp/Samples/SampleStyles.axaml
+++ b/samples/TestApp/TestApp/Samples/SampleStyles.axaml
@@ -14,4 +14,18 @@
         <Setter Property="TextWrapping" Value="Wrap" />
     </Style>
 
+    <!-- PillSelector: chrome-less horizontal ListBox with pill-shaped items -->
+    <Style Selector="ListBox.PillSelector">
+        <Setter Property="Background" Value="Transparent" />
+        <Setter Property="BorderThickness" Value="0" />
+        <Setter Property="Padding" Value="0" />
+    </Style>
+
+    <Style Selector="ListBox.PillSelector ListBoxItem">
+        <Setter Property="Padding" Value="12,6" />
+        <Setter Property="MinHeight" Value="0" />
+        <Setter Property="CornerRadius" Value="16" />
+        <Setter Property="Margin" Value="2,0" />
+    </Style>
+
 </Styles>


### PR DESCRIPTION
Replace the horizontal row of Ghost `EnhancedButton`s (which looked like an oversized button bar) with a styled `ListBox` using `WrapPanel` and a `PillSelector` style class for category filtering.

**What changed:**
- **SampleStyles.axaml**: New `PillSelector` style — chrome-less ListBox with pill-shaped ListBoxItems (`CornerRadius="16"`)
- **HomeView.axaml**: Category section now uses `ListBox.PillSelector` with `WrapPanel` — pills wrap to multiple rows instead of requiring horizontal scroll
- **HomeViewModel.cs**: Simplified — removed `SelectCategory`/`ClearCategory` commands, `Categories` includes "All" at the start, filter handles "All" as no-filter
- **HomeViewState.cs**: `SelectedCategory` defaults to `"All"` so it's visually selected on load

**UX improvements:**
- Native selection semantics with Fluent `:selected`/`:pointerover` states
- Pills wrap responsively — no horizontal scroll needed
- Cleaner ViewModel with 2 fewer commands