### PR TITLE
Embed MessageDialogViewModel DataTemplate in DialogControl

### DIFF
--- a/samples/TestApp/TestApp/App.axaml
+++ b/samples/TestApp/TestApp/App.axaml
@@ -1,6 +1,5 @@
 <Application xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             xmlns:views="clr-namespace:Zafiro.Avalonia.Dialogs.Views;assembly=Zafiro.Avalonia.Dialogs"
              xmlns:misc="clr-namespace:Zafiro.Avalonia.Misc;assembly=Zafiro.Avalonia"
              x:Class="TestApp.App"
              RequestedThemeVariant="Default">
@@ -80,9 +79,6 @@
 
     <Application.DataTemplates>
         <misc:DataTemplateInclude Source="avares://Zafiro.Avalonia/DataTemplates.axaml" />
-        <DataTemplate DataType="views:MessageDialogViewModel">
-            <MessageDialogView />
-        </DataTemplate>
         <DataTypeViewLocator />
         <NamingConventionGeneratedViewLocator />
     </Application.DataTemplates>

--- a/src/Zafiro.Avalonia.Dialogs/Views/DialogControl.axaml
+++ b/src/Zafiro.Avalonia.Dialogs/Views/DialogControl.axaml
@@ -23,6 +23,11 @@
         <Setter Property="Template">
             <ControlTemplate>
                 <DockPanel VerticalSpacing="8">
+                    <DockPanel.DataTemplates>
+                        <DataTemplate DataType="MessageDialogViewModel">
+                            <MessageDialogView />
+                        </DataTemplate>
+                    </DockPanel.DataTemplates>
                     <ItemsControl ItemsSource="{TemplateBinding Options}" DockPanel.Dock="Bottom" IsVisible="{TemplateBinding Options, Converter={x:Static Enumerable.NotEmpty}}">
                         <ItemsControl.ItemContainerTheme>
                             <ControlTheme TargetType="ContentPresenter">


### PR DESCRIPTION
The `MessageDialogViewModel` DataTemplate is now bundled inside `DialogControl`'s ControlTheme template. Consumers who already include `Zafiro.Avalonia.Dialogs/Styles.axaml` get the template automatically — no manual registration in `Application.DataTemplates` needed.

This eliminates a common pitfall where consumers forget to register the template and `ShowMessage()`/`ShowConfirmation()` renders raw ViewModel text instead of the expected UI.

**Changes:**
- `DialogControl.axaml`: Added `MessageDialogViewModel → MessageDialogView` DataTemplate inside the `DockPanel` of the ControlTheme template
- `TestApp/App.axaml`: Removed the now-redundant manual DataTemplate registration and unused `xmlns:views` import