### PR TITLE
Fix CI: remove non-buildable platform projects from slnx

### DIFF
--- a/Zafiro.Avalonia.slnx
+++ b/Zafiro.Avalonia.slnx
@@ -11,12 +11,8 @@
   </Folder>
   <Folder Name="/samples/">
     <Project Path="samples/MinimalShell/MinimalShell.csproj" />
-    <Project Path="samples/FileExplorer/SampleFileExplorer/SampleFileExplorer.csproj" />
     <Project Path="samples/TestApp/TestApp/TestApp.csproj" />
     <Project Path="samples/TestApp/TestApp.Desktop/TestApp.Desktop.csproj" />
-    <Project Path="samples/TestApp/TestApp.Browser/TestApp.Browser.csproj" />
-    <Project Path="samples/TestApp/TestApp.Android/TestApp.Android.csproj" />
-    <Project Path="samples/TestApp/TestApp.iOS/TestApp.iOS.csproj" />
   </Folder>
   <Folder Name="/Other files/">
     <File Path="azure-pipelines.yml" />


### PR DESCRIPTION
Remove platform-specific sample projects from `.slnx` that break CI:

- **TestApp.Android** (`net9.0-android`) — TFM mismatch with TestApp (`net10.0`)
- **TestApp.iOS** (`net7.0-ios`) — iOS workload unavailable on Linux CI
- **TestApp.Browser** (`net8.0-browser`) — stale TFM mismatch
- **SampleFileExplorer** — references non-existent `Zafiro.Avalonia.FileExplorer` project

These are platform heads not needed for NuGet packaging. The `.sln` already excludes them. The DotnetDeployer uses `.slnx` (preferred over `.sln`), so `dotnet pack` was failing on these unbuildable projects.

Verified locally: `dotnetdeployer --dry-run` completes successfully with 6 packages.