### PR TITLE
Configure GitHub Pages deployment for TestApp Browser (WASM)

### DIFF
--- a/Zafiro.Avalonia.slnx
+++ b/Zafiro.Avalonia.slnx
@@ -13,6 +13,7 @@
     <Project Path="samples/MinimalShell/MinimalShell.csproj" />
     <Project Path="samples/TestApp/TestApp/TestApp.csproj" />
     <Project Path="samples/TestApp/TestApp.Desktop/TestApp.Desktop.csproj" />
+    <Project Path="samples/TestApp/TestApp.Browser/TestApp.Browser.csproj" />
   </Folder>
   <Folder Name="/Other files/">
     <File Path="azure-pipelines.yml" />

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -33,10 +33,12 @@ steps:
     condition: and(succeeded(), not(or(eq(variables['Build.SourceBranch'], 'refs/heads/master'), eq(variables['Build.SourceBranch'], 'refs/heads/main'))))
     env:
       NUGET_API_KEY: $(NugetApiKey)
+      GITHUB_TOKEN: $(GitHubToken)
 
-  # Create and Publish NuGet packages (for master/main branch only)
+  # Create and Publish NuGet packages + deploy GitHub Pages (for master/main branch only)
   - pwsh: dotnetdeployer
-    displayName: Create and Publish NuGet packages
+    displayName: Create and Publish NuGet packages + deploy GitHub Pages
     condition: and(succeeded(), or(eq(variables['Build.SourceBranch'], 'refs/heads/master'), eq(variables['Build.SourceBranch'], 'refs/heads/main')))
     env:
       NUGET_API_KEY: $(NugetApiKey)
+      GITHUB_TOKEN: $(GitHubToken)

--- a/deployer.yaml
+++ b/deployer.yaml
@@ -2,3 +2,12 @@ nuget:
   enabled: true
   source: https://api.nuget.org/v3/index.json
   apiKeyEnvVar: NUGET_API_KEY
+
+githubPages:
+  enabled: true
+  owner: SuperJMN
+  repo: Zafiro.Avalonia.github.io
+  tokenEnvVar: GITHUB_TOKEN
+  branch: master
+  projects:
+    - project: samples/TestApp/TestApp.Browser/TestApp.Browser.csproj

--- a/samples/TestApp/TestApp.Browser/TestApp.Browser.csproj
+++ b/samples/TestApp/TestApp.Browser/TestApp.Browser.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk.WebAssembly">
     <PropertyGroup>
-        <TargetFramework>net8.0-browser</TargetFramework>
+        <TargetFramework>net10.0-browser</TargetFramework>
         <OutputType>Exe</OutputType>
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
         <WasmBuildNative>true</WasmBuildNative>


### PR DESCRIPTION
Enable automatic deployment of the TestApp Browser (WASM) app to GitHub Pages via DotnetDeployer.

## Changes

- **TestApp.Browser.csproj**: Updated TFM from `net8.0-browser` to `net10.0-browser` to match the rest of the solution
- **Zafiro.Avalonia.slnx**: Re-added `TestApp.Browser` so `dotnet workload restore` installs the WASM workload
- **deployer.yaml**: Added `githubPages` section targeting `SuperJMN/Zafiro.Avalonia:gh-pages`
- **azure-pipelines.yml**: Pass `GITHUB_TOKEN` env var to DotnetDeployer steps

## Prerequisites

A `GitHubToken` variable with push access must be added to the `api-keys` variable group in Azure DevOps. After merge, GitHub Pages needs to be configured to serve from the `gh-pages` branch.