### PR TITLE
feat: add Color editor to PropertyGrid using Avalonia ColorPicker

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -9,6 +9,7 @@
     <PackageVersion Include="Avalonia" Version="$(AvaloniaVersion)"/>
     <PackageVersion Include="Avalonia.Android" Version="$(AvaloniaVersion)"/>
     <PackageVersion Include="Avalonia.Browser" Version="$(AvaloniaVersion)"/>
+    <PackageVersion Include="Avalonia.Controls.ColorPicker" Version="$(AvaloniaVersion)"/>
     <PackageVersion Include="Avalonia.Controls.DataGrid" Version="$(AvaloniaVersion)"/>
     <PackageVersion Include="Avalonia.Desktop" Version="$(AvaloniaVersion)"/>
     <PackageVersion Include="Avalonia.Fonts.Inter" Version="$(AvaloniaVersion)"/>

--- a/src/Zafiro.Avalonia/Controls/PropertyGrid/PropertyGrid.axaml
+++ b/src/Zafiro.Avalonia/Controls/PropertyGrid/PropertyGrid.axaml
@@ -33,6 +33,9 @@
                 <DataTemplate x:Key="System.Double" DataType="viewModels:IPropertyItem">
                     <NumericUpDown Value="{Binding Value}" />
                 </DataTemplate>
+                <DataTemplate x:Key="Avalonia.Media.Color" DataType="viewModels:IPropertyItem">
+                    <ColorPicker Color="{Binding Value}" HorizontalAlignment="Stretch" />
+                </DataTemplate>
             </propertyGrid:PropertyEditorSelector.Editors>
         </propertyGrid:PropertyEditorSelector>
     </UserControl.Resources>

--- a/src/Zafiro.Avalonia/Styles.axaml
+++ b/src/Zafiro.Avalonia/Styles.axaml
@@ -69,4 +69,6 @@
     <StyleInclude Source="Controls/ProgressControl.axaml" />
     <StyleInclude Source="GraphWizard/View/GraphWizardView.axaml" />
 
+    <StyleInclude Source="avares://Avalonia.Controls.ColorPicker/Themes/Fluent/Fluent.xaml" />
+
 </Styles>

--- a/src/Zafiro.Avalonia/Zafiro.Avalonia.csproj
+++ b/src/Zafiro.Avalonia/Zafiro.Avalonia.csproj
@@ -10,6 +10,7 @@
     <Import Project="..\Common.props"/>
     <ItemGroup>
         <PackageReference Include="Avalonia"/>
+        <PackageReference Include="Avalonia.Controls.ColorPicker"/>
         <PackageReference Include="Avalonia.Controls.DataGrid"/>
         <PackageReference Include="Avalonia.Skia"/>
         <PackageReference Include="CSharpFunctionalExtensions"/>


### PR DESCRIPTION
## Summary

Adds a `Color` editor to the PropertyGrid control, using Avalonia's built-in `ColorPicker` from the `Avalonia.Controls.ColorPicker` package.

## Changes

- **`Directory.Packages.props`**: Added `Avalonia.Controls.ColorPicker` version aligned with `$(AvaloniaVersion)` (12.0.0)
- **`Zafiro.Avalonia.csproj`**: Added `PackageReference` for `Avalonia.Controls.ColorPicker`
- **`PropertyGrid.axaml`**: Registered `ColorPicker` as the editor for `Avalonia.Media.Color` type in the `PropertyEditorSelector`
- **`Styles.axaml`**: Included `Fluent.xaml` theme from `Avalonia.Controls.ColorPicker` so consumers don't need to add it manually

## Motivation

The PropertyGrid currently supports `string`, `bool`, `int`, `double`, and `enum` types. Many use cases (especially visual effects and styling) require editing `Color` properties. Avalonia 12 ships a fully-featured `ColorPicker` in a separate NuGet package — this PR leverages it directly rather than building a custom control.

## Usage

Any object with a property of type `Avalonia.Media.Color` passed to `PropertyGrid.SelectedObjects` will now automatically get a compact ColorPicker dropdown editor.