### PR TITLE
fix: DataTypeViewLocatorGenerator registers interface type, not resolved concrete implementation

### DIFF
--- a/src/Zafiro.Avalonia.Generators/DataTypeViewLocatorGenerator.cs
+++ b/src/Zafiro.Avalonia.Generators/DataTypeViewLocatorGenerator.cs
@@ -98,58 +98,35 @@ public class DataTypeViewLocatorGenerator : IIncrementalGenerator
             var vmSymbol = compilation.GetTypeByMetadataName(vmFullNameFromXaml);
             var chosenVmFullName = vmFullNameFromXaml;
 
+            // When x:DataType is an interface, register the interface itself as the key.
+            // DataTypeViewLocator.TryFromRegistry already resolves interface-keyed entries at
+            // runtime (step 2: "match by any implemented interface"), so all concrete
+            // implementations of the interface will be served by the same view without
+            // needing individual registrations.
+            //
+            // The old approach resolved to ONE concrete implementation by naming convention,
+            // which left other implementations (e.g. AdventureTeamPickerViewModel) unregistered,
+            // causing DataTypeViewLocator.Match() to return false and Avalonia to fall back to
+            // ToString().
             if (vmSymbol is INamedTypeSymbol named && named.TypeKind == TypeKind.Interface)
             {
-                var viewId = GetViewIdentifier(classAttr);
-
-                var impls = EnumerateAllTypes(compilation.GlobalNamespace)
+                var hasImpls = EnumerateAllTypes(compilation.GlobalNamespace)
                     .OfType<INamedTypeSymbol>()
-                    .Where(t => t.TypeKind == TypeKind.Class && !t.IsAbstract && Implements(t, named))
-                    .OrderBy(t => t.ToDisplayString())
-                    .ToList();
+                    .Any(t => t.TypeKind == TypeKind.Class && !t.IsAbstract && Implements(t, named));
 
-                if (impls.Count > 0)
-                {
-                    var matching = impls.FirstOrDefault(t => GetViewModelIdentifier(t.Name).Equals(viewId, StringComparison.Ordinal));
-
-                    var chosen = matching ?? impls.First();
-                    chosenVmFullName = ToQualifiedName(chosen);
-
-                    if (impls.Count > 1)
-                    {
-                        var descriptor = new DiagnosticDescriptor(
-                            id: "ZAV0002",
-                            title: "Multiple implementations for interface",
-                            messageFormat: $"Multiple implementations found for interface {named.ToDisplayString()}. Using {chosenVmFullName} for view {classAttr}",
-                            category: "ViewLocation",
-                            DiagnosticSeverity.Warning,
-                            isEnabledByDefault: true);
-                        context.ReportDiagnostic(Diagnostic.Create(descriptor, Location.None));
-                    }
-
-                    if (matching is null && impls.Count >= 1)
-                    {
-                        var descriptorNoMatch = new DiagnosticDescriptor(
-                            id: "ZAV0003",
-                            title: "No identifier match for interface implementations",
-                            messageFormat: $"No implementation matching identifier '{viewId}' for interface {named.ToDisplayString()} and view {classAttr}. Using {chosenVmFullName}",
-                            category: "ViewLocation",
-                            DiagnosticSeverity.Warning,
-                            isEnabledByDefault: true);
-                        context.ReportDiagnostic(Diagnostic.Create(descriptorNoMatch, Location.None));
-                    }
-                }
-                else
+                if (!hasImpls)
                 {
                     var descriptorNone = new DiagnosticDescriptor(
                         id: "ZAV0004",
                         title: "No implementations found for interface",
-                        messageFormat: $"No implementations found for interface {named.ToDisplayString()} referenced by view {classAttr}. Keeping interface mapping.",
+                        messageFormat: $"No implementations found for interface {named.ToDisplayString()} referenced by view {classAttr}. The interface mapping will be registered but may never match.",
                         category: "ViewLocation",
                         DiagnosticSeverity.Warning,
                         isEnabledByDefault: true);
                     context.ReportDiagnostic(Diagnostic.Create(descriptorNone, Location.None));
                 }
+
+                // chosenVmFullName stays as vmFullNameFromXaml (the interface type)
             }
 
             rawPairs.Add((chosenVmFullName, classAttr));
@@ -194,34 +171,6 @@ public class DataTypeViewLocatorGenerator : IIncrementalGenerator
     private static bool Implements(INamedTypeSymbol type, INamedTypeSymbol @interface)
     {
         return type.AllInterfaces.Any(i => SymbolEqualityComparer.Default.Equals(i, @interface));
-    }
-
-    private static string GetViewIdentifier(string viewFullName)
-    {
-        var simple = viewFullName.Split('.').Last();
-        return simple.EndsWith("View", StringComparison.Ordinal)
-            ? simple.Substring(0, simple.Length - "View".Length)
-            : simple;
-    }
-
-    private static string GetViewModelIdentifier(string vmSimpleName)
-    {
-        return vmSimpleName.EndsWith("ViewModel", StringComparison.Ordinal)
-            ? vmSimpleName.Substring(0, vmSimpleName.Length - "ViewModel".Length)
-            : vmSimpleName;
-    }
-
-    private static string ToQualifiedName(INamedTypeSymbol type)
-    {
-        var parts = new Stack<string>();
-        for (var t = type; t is not null; t = t.ContainingType)
-        {
-            parts.Push(t.Name);
-        }
-
-        var ns = type.ContainingNamespace?.ToDisplayString();
-        var name = string.Join(".", parts);
-        return string.IsNullOrEmpty(ns) ? name : ns + "." + name;
     }
 
     private static IEnumerable<INamedTypeSymbol> EnumerateAllTypes(INamespaceSymbol ns)

--- a/test/Zafiro.Avalonia.Tests/DataTypeViewLocatorGeneratorTests.cs
+++ b/test/Zafiro.Avalonia.Tests/DataTypeViewLocatorGeneratorTests.cs
@@ -1,0 +1,171 @@
+using System.Collections.Immutable;
+using System.Reflection;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Text;
+using Zafiro.Avalonia.Generators;
+
+namespace Zafiro.Avalonia.Tests;
+
+public class DataTypeViewLocatorGeneratorTests
+{
+    // Minimal Avalonia Control stub so the generator can compile against a "Control" type
+    private const string AvaloniaStub = """
+        namespace Avalonia.Controls
+        {
+            public class Control { }
+            public class UserControl : Control { }
+        }
+        """;
+
+    private const string LocatorStub = """
+        namespace Zafiro.Avalonia.ViewLocators
+        {
+            public static class DataTypeViewLocator
+            {
+                public static void RegisterGlobal<TViewModel, TView>() where TView : global::Avalonia.Controls.Control, new() { }
+            }
+        }
+        """;
+
+    /// <summary>
+    /// When x:DataType is an interface implemented by exactly one class the interface
+    /// itself should be the registered key (not the concrete class).
+    /// </summary>
+    [Fact]
+    public void Interface_with_single_implementation_registers_interface_not_concrete_type()
+    {
+        const string csSource = """
+            namespace MyApp
+            {
+                public interface IFooViewModel { }
+                public class FooViewModel : IFooViewModel { }
+                public class FooView : global::Avalonia.Controls.UserControl { }
+            }
+            """;
+
+        const string axaml = """
+            <UserControl xmlns="https://github.com/avaloniaui"
+                         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                         xmlns:app="clr-namespace:MyApp"
+                         x:Class="MyApp.FooView"
+                         x:DataType="app:IFooViewModel">
+            </UserControl>
+            """;
+
+        var generated = RunGenerator(csSource, ("FooView.axaml", axaml));
+
+        Assert.Contains("RegisterGlobal<global::MyApp.IFooViewModel, global::MyApp.FooView>()", generated);
+        Assert.DoesNotContain("RegisterGlobal<global::MyApp.FooViewModel,", generated);
+    }
+
+    /// <summary>
+    /// When x:DataType is an interface implemented by multiple classes the interface
+    /// is still registered — ALL implementations can then be resolved at runtime.
+    /// </summary>
+    [Fact]
+    public void Interface_with_multiple_implementations_registers_interface_not_one_concrete_type()
+    {
+        const string csSource = """
+            namespace MyApp
+            {
+                public interface IFooViewModel { }
+                public class FooViewModel : IFooViewModel { }
+                public class AnotherFooViewModel : IFooViewModel { }
+                public class FooView : global::Avalonia.Controls.UserControl { }
+            }
+            """;
+
+        const string axaml = """
+            <UserControl xmlns="https://github.com/avaloniaui"
+                         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                         xmlns:app="clr-namespace:MyApp"
+                         x:Class="MyApp.FooView"
+                         x:DataType="app:IFooViewModel">
+            </UserControl>
+            """;
+
+        var generated = RunGenerator(csSource, ("FooView.axaml", axaml));
+
+        Assert.Contains("RegisterGlobal<global::MyApp.IFooViewModel, global::MyApp.FooView>()", generated);
+        Assert.DoesNotContain("RegisterGlobal<global::MyApp.FooViewModel,", generated);
+        Assert.DoesNotContain("RegisterGlobal<global::MyApp.AnotherFooViewModel,", generated);
+    }
+
+    /// <summary>
+    /// When x:DataType is a concrete class (not an interface), that class is registered as-is.
+    /// </summary>
+    [Fact]
+    public void Concrete_viewmodel_registers_concrete_type()
+    {
+        const string csSource = """
+            namespace MyApp
+            {
+                public class FooViewModel { }
+                public class FooView : global::Avalonia.Controls.UserControl { }
+            }
+            """;
+
+        const string axaml = """
+            <UserControl xmlns="https://github.com/avaloniaui"
+                         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                         xmlns:app="clr-namespace:MyApp"
+                         x:Class="MyApp.FooView"
+                         x:DataType="app:FooViewModel">
+            </UserControl>
+            """;
+
+        var generated = RunGenerator(csSource, ("FooView.axaml", axaml));
+
+        Assert.Contains("RegisterGlobal<global::MyApp.FooViewModel, global::MyApp.FooView>()", generated);
+    }
+
+    // -------------------------------------------------------------------------
+
+    private string RunGenerator(string csSource, params (string fileName, string content)[] axamlFiles)
+    {
+        var syntaxTrees = new[]
+        {
+            CSharpSyntaxTree.ParseText(AvaloniaStub),
+            CSharpSyntaxTree.ParseText(LocatorStub),
+            CSharpSyntaxTree.ParseText(csSource),
+        };
+
+        var compilation = CSharpCompilation.Create(
+            assemblyName: "TestAssembly",
+            syntaxTrees: syntaxTrees,
+            references:
+            [
+                MetadataReference.CreateFromFile(typeof(object).Assembly.Location),
+                MetadataReference.CreateFromFile(typeof(Attribute).Assembly.Location),
+                MetadataReference.CreateFromFile(typeof(Enumerable).Assembly.Location),
+                MetadataReference.CreateFromFile(Assembly.Load("System.Runtime").Location),
+            ],
+            options: new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+
+        var additionalTexts = axamlFiles
+            .Select(f => (Microsoft.CodeAnalysis.AdditionalText)new InMemoryAdditionalText(f.fileName, f.content))
+            .ToImmutableArray();
+
+        GeneratorDriver driver = CSharpGeneratorDriver
+            .Create(new DataTypeViewLocatorGenerator())
+            .AddAdditionalTexts(additionalTexts);
+
+        driver = driver.RunGeneratorsAndUpdateCompilation(compilation, out _, out _);
+
+        return driver.GetRunResult()
+            .Results
+            .Single()
+            .GeneratedSources
+            .Single(s => s.HintName == "DataTypeViewLocator.GlobalRegistrations.g.cs")
+            .SourceText
+            .ToString();
+    }
+
+    private sealed class InMemoryAdditionalText(string path, string content) : Microsoft.CodeAnalysis.AdditionalText
+    {
+        public override string Path { get; } = path;
+        public override SourceText GetText(System.Threading.CancellationToken cancellationToken = default)
+            => SourceText.From(content);
+    }
+}


### PR DESCRIPTION
## Problema

Cuando `x:DataType` es una **interfaz**, el generador buscaba todas las implementaciones concretas, elegía una por convención de nombres y registraba **esa clase concreta** como clave. Las otras implementaciones quedaban sin registrar.

### Ejemplo concreto (Pokemon)

`TeamSelectionView` declara `x:DataType="ITeamSelectionViewModel"`.  
El generador encontraba dos implementaciones:
- `TeamSelectionViewModel` → identificador `"TeamSelection"` ✅ match con `"TeamSelection"View`
- `AdventureTeamPickerViewModel` → identificador `"AdventureTeamPicker"` ❌ no match

Resultado generado:
```csharp
RegisterGlobal<TeamSelectionViewModel, TeamSelectionView>();
```

`AdventureTeamPickerViewModel` nunca quedaba registrado → `DataTypeViewLocator.Match()` devolvía `false` → Avalonia mostraba `ToString()` en lugar de la vista.

## Causa raíz

El generador resolvía el tipo interfaz a **una sola implementación concreta**. Esto es incorrecto: la declaración `x:DataType="IFoo"` significa _"esta vista sirve a cualquier implementación de IFoo"_.

## Fix

Cuando `x:DataType` es una interfaz, el generador ahora registra **la interfaz misma** como clave:

```csharp
RegisterGlobal<ITeamSelectionViewModel, TeamSelectionView>();
```

`DataTypeViewLocator.TryFromRegistry` ya implementaba el lookup por interfaz (paso 2: _"match by any implemented interface"_), por lo que **todas** las implementaciones se resuelven automáticamente en runtime sin cambios adicionales.

## Cambios

- **Generator**: elimina la resolución interfaz→concreto; registra la interfaz directamente.
- **Diagnostics eliminados**: `ZAV0002` ("múltiples implementaciones, usando X") y `ZAV0003` ("sin match de identificador") — ya no aplican. Se mantiene `ZAV0004` ("ninguna implementación encontrada") como aviso útil.
- **Helpers eliminados**: `GetViewIdentifier`, `GetViewModelIdentifier`, `ToQualifiedName` — ya no se usan.
- **Tests nuevos** (3): interfaz con 1 impl → clave es la interfaz; interfaz con N impls → clave es la interfaz; clase concreta → sin cambios.
