### PR TITLE
Adaptive content-driven dialog sizing

### DIFF
--- a/src/Zafiro.Avalonia.Dialogs/DialogExtensions.cs
+++ b/src/Zafiro.Avalonia.Dialogs/DialogExtensions.cs
@@ -18,67 +18,67 @@ public static class DialogExtensions
 
     #region Show Overloads
 
-    public static Task<bool> Show<TViewModel>(this IDialog dialog, TViewModel? viewModel, string title, Func<TViewModel, ICloseable, IEnumerable<IOption>> optionsFactory, object? icon = null, DialogTone tone = DialogTone.Neutral) where TViewModel : class
+    public static Task<bool> Show<TViewModel>(this IDialog dialog, TViewModel? viewModel, string title, Func<TViewModel, ICloseable, IEnumerable<IOption>> optionsFactory, object? icon = null, DialogTone tone = DialogTone.Neutral, DialogSize size = DialogSize.Auto) where TViewModel : class
     {
-        return dialog.Show(viewModel.ToMaybe(), Title(title), (vm, closeable) => optionsFactory(vm.GetValueOrDefault()!, closeable), icon.ToMaybe(), tone);
+        return dialog.Show(viewModel.ToMaybe(), Title(title), (vm, closeable) => optionsFactory(vm.GetValueOrDefault()!, closeable), icon.ToMaybe(), tone, size);
     }
 
-    public static Task<bool> Show<TViewModel>(this IDialog dialog, TViewModel? viewModel, IObservable<string> title, Func<TViewModel, ICloseable, IEnumerable<IOption>> optionsFactory, object? icon = null, DialogTone tone = DialogTone.Neutral) where TViewModel : class
+    public static Task<bool> Show<TViewModel>(this IDialog dialog, TViewModel? viewModel, IObservable<string> title, Func<TViewModel, ICloseable, IEnumerable<IOption>> optionsFactory, object? icon = null, DialogTone tone = DialogTone.Neutral, DialogSize size = DialogSize.Auto) where TViewModel : class
     {
-        return dialog.Show(viewModel.ToMaybe(), title.ToMaybe(), (vm, closeable) => optionsFactory(vm.GetValueOrDefault()!, closeable), icon.ToMaybe(), tone);
+        return dialog.Show(viewModel.ToMaybe(), title.ToMaybe(), (vm, closeable) => optionsFactory(vm.GetValueOrDefault()!, closeable), icon.ToMaybe(), tone, size);
     }
 
-    public static Task<bool> Show<TViewModel>(this IDialog dialog, TViewModel viewModel, Func<TViewModel, ICloseable, IEnumerable<IOption>> optionsFactory, object? icon = null, DialogTone tone = DialogTone.Neutral) where TViewModel : class, IHaveTitle
+    public static Task<bool> Show<TViewModel>(this IDialog dialog, TViewModel viewModel, Func<TViewModel, ICloseable, IEnumerable<IOption>> optionsFactory, object? icon = null, DialogTone tone = DialogTone.Neutral, DialogSize size = DialogSize.Auto) where TViewModel : class, IHaveTitle
     {
-        return dialog.Show(viewModel.ToMaybe(), viewModel.Title.ToMaybe(), (vm, closeable) => optionsFactory(vm.GetValueOrDefault()!, closeable), icon.ToMaybe(), tone);
+        return dialog.Show(viewModel.ToMaybe(), viewModel.Title.ToMaybe(), (vm, closeable) => optionsFactory(vm.GetValueOrDefault()!, closeable), icon.ToMaybe(), tone, size);
     }
 
-    public static Task<bool> Show<TViewModel>(this IDialog dialog, TViewModel? viewModel, string title, Func<ICloseable, IEnumerable<IOption>> optionsFactory, object? icon = null, DialogTone tone = DialogTone.Neutral) where TViewModel : class
+    public static Task<bool> Show<TViewModel>(this IDialog dialog, TViewModel? viewModel, string title, Func<ICloseable, IEnumerable<IOption>> optionsFactory, object? icon = null, DialogTone tone = DialogTone.Neutral, DialogSize size = DialogSize.Auto) where TViewModel : class
     {
-        return dialog.Show(viewModel.ToMaybe(), Title(title), (_, closeable) => optionsFactory(closeable), icon.ToMaybe(), tone);
+        return dialog.Show(viewModel.ToMaybe(), Title(title), (_, closeable) => optionsFactory(closeable), icon.ToMaybe(), tone, size);
     }
 
-    public static Task<bool> Show<TViewModel>(this IDialog dialog, TViewModel viewModel, Func<ICloseable, IEnumerable<IOption>> optionsFactory, object? icon = null, DialogTone tone = DialogTone.Neutral) where TViewModel : class, IHaveTitle
+    public static Task<bool> Show<TViewModel>(this IDialog dialog, TViewModel viewModel, Func<ICloseable, IEnumerable<IOption>> optionsFactory, object? icon = null, DialogTone tone = DialogTone.Neutral, DialogSize size = DialogSize.Auto) where TViewModel : class, IHaveTitle
     {
-        return dialog.Show(viewModel.ToMaybe(), viewModel.Title.ToMaybe(), (_, closeable) => optionsFactory(closeable), icon.ToMaybe(), tone);
+        return dialog.Show(viewModel.ToMaybe(), viewModel.Title.ToMaybe(), (_, closeable) => optionsFactory(closeable), icon.ToMaybe(), tone, size);
     }
 
-    public static Task<bool> Show(this IDialog dialog, string title, Func<ICloseable, IEnumerable<IOption>> optionsFactory, object? icon = null, DialogTone tone = DialogTone.Neutral)
+    public static Task<bool> Show(this IDialog dialog, string title, Func<ICloseable, IEnumerable<IOption>> optionsFactory, object? icon = null, DialogTone tone = DialogTone.Neutral, DialogSize size = DialogSize.Auto)
     {
-        return dialog.Show(Maybe<object>.None, Title(title), (_, closeable) => optionsFactory(closeable), icon.ToMaybe(), tone);
+        return dialog.Show(Maybe<object>.None, Title(title), (_, closeable) => optionsFactory(closeable), icon.ToMaybe(), tone, size);
     }
 
-    public static Task<bool> Show(this IDialog dialog, IObservable<string> title, Func<ICloseable, IEnumerable<IOption>> optionsFactory, object? icon = null, DialogTone tone = DialogTone.Neutral)
+    public static Task<bool> Show(this IDialog dialog, IObservable<string> title, Func<ICloseable, IEnumerable<IOption>> optionsFactory, object? icon = null, DialogTone tone = DialogTone.Neutral, DialogSize size = DialogSize.Auto)
     {
-        return dialog.Show(Maybe<object>.None, title.ToMaybe(), (_, closeable) => optionsFactory(closeable), icon.ToMaybe(), tone);
+        return dialog.Show(Maybe<object>.None, title.ToMaybe(), (_, closeable) => optionsFactory(closeable), icon.ToMaybe(), tone, size);
     }
 
     #endregion
 
     #region ShowOk / ShowOkCancel
 
-    public static Task ShowOk<TViewModel>(this IDialog dialogService, TViewModel? viewModel, string title, Func<TViewModel?, IObservable<bool>>? canSubmit = null, object? icon = null, DialogTone tone = DialogTone.Neutral) where TViewModel : class
-        => dialogService.ShowOk(viewModel, Observable.Return(title), canSubmit, icon, tone);
+    public static Task ShowOk<TViewModel>(this IDialog dialogService, TViewModel? viewModel, string title, Func<TViewModel?, IObservable<bool>>? canSubmit = null, object? icon = null, DialogTone tone = DialogTone.Neutral, DialogSize size = DialogSize.Auto) where TViewModel : class
+        => dialogService.ShowOk(viewModel, Observable.Return(title), canSubmit, icon, tone, size);
 
-    public static Task ShowOk<TViewModel>(this IDialog dialogService, TViewModel viewModel, Func<TViewModel?, IObservable<bool>>? canSubmit = null, object? icon = null, DialogTone tone = DialogTone.Neutral) where TViewModel : class, IHaveTitle
-        => dialogService.ShowOk(viewModel, viewModel.Title, canSubmit, icon, tone);
+    public static Task ShowOk<TViewModel>(this IDialog dialogService, TViewModel viewModel, Func<TViewModel?, IObservable<bool>>? canSubmit = null, object? icon = null, DialogTone tone = DialogTone.Neutral, DialogSize size = DialogSize.Auto) where TViewModel : class, IHaveTitle
+        => dialogService.ShowOk(viewModel, viewModel.Title, canSubmit, icon, tone, size);
 
-    public static Task ShowOk<TViewModel>(this IDialog dialogService, TViewModel? viewModel, IObservable<string> title, Func<TViewModel?, IObservable<bool>>? canSubmit = null, object? icon = null, DialogTone tone = DialogTone.Neutral) where TViewModel : class
+    public static Task ShowOk<TViewModel>(this IDialog dialogService, TViewModel? viewModel, IObservable<string> title, Func<TViewModel?, IObservable<bool>>? canSubmit = null, object? icon = null, DialogTone tone = DialogTone.Neutral, DialogSize size = DialogSize.Auto) where TViewModel : class
     {
         return dialogService.Show(viewModel.ToMaybe(), title.ToMaybe(), (vm, closeable) =>
         {
             var canExecute = canSubmit?.Invoke(vm.GetValueOrDefault()) ?? Observable.Return(true);
             return [Ok(closeable, canExecute)];
-        }, icon.ToMaybe(), tone);
+        }, icon.ToMaybe(), tone, size);
     }
 
-    public static Task ShowOk(this IDialog dialogService, string title, IObservable<bool>? canSubmit = null, object? icon = null, DialogTone tone = DialogTone.Neutral)
+    public static Task ShowOk(this IDialog dialogService, string title, IObservable<bool>? canSubmit = null, object? icon = null, DialogTone tone = DialogTone.Neutral, DialogSize size = DialogSize.Auto)
     {
         return dialogService.Show(Maybe<object>.None, Title(title), (_, closeable) =>
         {
             var canExecute = canSubmit ?? Observable.Return(true);
             return [Ok(closeable, canExecute)];
-        }, icon.ToMaybe(), tone);
+        }, icon.ToMaybe(), tone, size);
     }
 
     public static Task Show<TViewModel>(this IDialog dialogService,
@@ -86,21 +86,23 @@ public static class DialogExtensions
         string title,
         IObservable<bool>? canSubmit,
         object? icon = null,
-        DialogTone tone = DialogTone.Neutral) where TViewModel : class
-        => dialogService.Show(viewModel, Observable.Return(title), canSubmit, icon, tone);
+        DialogTone tone = DialogTone.Neutral,
+        DialogSize size = DialogSize.Auto) where TViewModel : class
+        => dialogService.Show(viewModel, Observable.Return(title), canSubmit, icon, tone, size);
 
     public static Task Show<TViewModel>(this IDialog dialogService,
         TViewModel? viewModel,
         IObservable<string> title,
         IObservable<bool>? canSubmit,
         object? icon = null,
-        DialogTone tone = DialogTone.Neutral) where TViewModel : class
+        DialogTone tone = DialogTone.Neutral,
+        DialogSize size = DialogSize.Auto) where TViewModel : class
     {
         return dialogService.Show(viewModel.ToMaybe(), title.ToMaybe(), (_, closeable) =>
         [
             Cancel(closeable),
             Ok(closeable, canSubmit ?? Observable.Return(true))
-        ], icon.ToMaybe(), tone);
+        ], icon.ToMaybe(), tone, size);
     }
 
     #endregion
@@ -113,9 +115,10 @@ public static class DialogExtensions
         Func<TViewModel, ICloseable, IEnumerable<IOption>> optionsFactory,
         Func<TViewModel, Task<TResult>> getResult,
         object? icon = null,
-        DialogTone tone = DialogTone.Neutral) where TViewModel : class
+        DialogTone tone = DialogTone.Neutral,
+        DialogSize size = DialogSize.Auto) where TViewModel : class
     {
-        var isSuccess = await dialogService.Show(viewModel.ToMaybe(), title.ToMaybe(), (vm, c) => optionsFactory(vm.GetValueOrDefault()!, c), icon.ToMaybe(), tone);
+        var isSuccess = await dialogService.Show(viewModel.ToMaybe(), title.ToMaybe(), (vm, c) => optionsFactory(vm.GetValueOrDefault()!, c), icon.ToMaybe(), tone, size);
         if (isSuccess)
         {
             return await getResult(viewModel);
@@ -130,8 +133,9 @@ public static class DialogExtensions
         Func<ICloseable, IEnumerable<IOption>> optionsFactory,
         Func<TViewModel, Task<TResult>> getResult,
         object? icon = null,
-        DialogTone tone = DialogTone.Neutral) where TViewModel : class
-        => dialogService.ShowAndGetResult(viewModel, title, (_, closeable) => optionsFactory(closeable), getResult, icon, tone);
+        DialogTone tone = DialogTone.Neutral,
+        DialogSize size = DialogSize.Auto) where TViewModel : class
+        => dialogService.ShowAndGetResult(viewModel, title, (_, closeable) => optionsFactory(closeable), getResult, icon, tone, size);
 
     public static Task<Maybe<TResult>> ShowAndGetResult<TViewModel, TResult>(this IDialog dialogService,
         [DisallowNull] TViewModel viewModel,
@@ -139,8 +143,9 @@ public static class DialogExtensions
         Func<TViewModel, ICloseable, IEnumerable<IOption>> optionsFactory,
         Func<TViewModel, Task<TResult>> getResult,
         object? icon = null,
-        DialogTone tone = DialogTone.Neutral) where TViewModel : class
-        => dialogService.ShowAndGetResult(viewModel, Observable.Return(title), optionsFactory, getResult, icon, tone);
+        DialogTone tone = DialogTone.Neutral,
+        DialogSize size = DialogSize.Auto) where TViewModel : class
+        => dialogService.ShowAndGetResult(viewModel, Observable.Return(title), optionsFactory, getResult, icon, tone, size);
 
     public static Task<Maybe<TResult>> ShowAndGetResult<TViewModel, TResult>(this IDialog dialogService,
         [DisallowNull] TViewModel viewModel,
@@ -148,8 +153,9 @@ public static class DialogExtensions
         Func<TViewModel, ICloseable, IEnumerable<IOption>> optionsFactory,
         Func<TViewModel, TResult> getResult,
         object? icon = null,
-        DialogTone tone = DialogTone.Neutral) where TViewModel : class
-        => dialogService.ShowAndGetResult(viewModel, title, optionsFactory, vm => Task.FromResult(getResult(vm)), icon, tone);
+        DialogTone tone = DialogTone.Neutral,
+        DialogSize size = DialogSize.Auto) where TViewModel : class
+        => dialogService.ShowAndGetResult(viewModel, title, optionsFactory, vm => Task.FromResult(getResult(vm)), icon, tone, size);
 
     public static Task<Maybe<TResult>> ShowAndGetResult<TViewModel, TResult>(this IDialog dialogService,
         [DisallowNull] TViewModel viewModel,
@@ -157,8 +163,9 @@ public static class DialogExtensions
         Func<TViewModel, ICloseable, IEnumerable<IOption>> optionsFactory,
         Func<TViewModel, TResult> getResult,
         object? icon = null,
-        DialogTone tone = DialogTone.Neutral) where TViewModel : class
-        => dialogService.ShowAndGetResult(viewModel, Observable.Return(title), optionsFactory, vm => Task.FromResult(getResult(vm)), icon, tone);
+        DialogTone tone = DialogTone.Neutral,
+        DialogSize size = DialogSize.Auto) where TViewModel : class
+        => dialogService.ShowAndGetResult(viewModel, Observable.Return(title), optionsFactory, vm => Task.FromResult(getResult(vm)), icon, tone, size);
 
     // Convenience for IValidatable
     public static async Task<Maybe<TResult>> ShowAndGetResult<TViewModel, TResult>(this IDialog dialogService,
@@ -166,13 +173,14 @@ public static class DialogExtensions
         string title,
         Func<TViewModel, Task<TResult>> getResult,
         object? icon = null,
-        DialogTone tone = DialogTone.Neutral) where TViewModel : class, IValidatable
+        DialogTone tone = DialogTone.Neutral,
+        DialogSize size = DialogSize.Auto) where TViewModel : class, IValidatable
     {
         return await dialogService.ShowAndGetResult(viewModel, Observable.Return(title), (vm, closeable) =>
         [
             Cancel(closeable),
             Ok(closeable, vm!.IsValid)
-        ], getResult, icon, tone);
+        ], getResult, icon, tone, size);
     }
 
     public static async Task<Maybe<TResult>> ShowAndGetResult<TViewModel, TResult>(this IDialog dialogService,
@@ -180,13 +188,14 @@ public static class DialogExtensions
         string title,
         Func<TViewModel, TResult> getResult,
         object? icon = null,
-        DialogTone tone = DialogTone.Neutral) where TViewModel : class, IValidatable
+        DialogTone tone = DialogTone.Neutral,
+        DialogSize size = DialogSize.Auto) where TViewModel : class, IValidatable
     {
         return await dialogService.ShowAndGetResult(viewModel, Observable.Return(title), (vm, closeable) =>
         [
             Cancel(closeable),
             Ok(closeable, vm!.IsValid)
-        ], vm => Task.FromResult(getResult(vm)), icon, tone);
+        ], vm => Task.FromResult(getResult(vm)), icon, tone, size);
     }
 
     public static async Task<Maybe<TResult>> ShowAndGetResult<TViewModel, TResult>(this IDialog dialogService,
@@ -195,13 +204,14 @@ public static class DialogExtensions
         Func<TViewModel, IObservable<bool>> isValid,
         Func<TViewModel, TResult> getResult,
         object? icon = null,
-        DialogTone tone = DialogTone.Neutral) where TViewModel : class
+        DialogTone tone = DialogTone.Neutral,
+        DialogSize size = DialogSize.Auto) where TViewModel : class
     {
         return await dialogService.ShowAndGetResult(viewModel, Observable.Return(title), (vm, closeable) =>
         [
             Cancel(closeable),
             Ok(closeable, isValid(vm!))
-        ], vm => Task.FromResult(getResult(vm)), icon, tone);
+        ], vm => Task.FromResult(getResult(vm)), icon, tone, size);
     }
 
     // Command Result Variant
@@ -210,7 +220,8 @@ public static class DialogExtensions
         IObservable<string> title,
         Func<TViewModel, IEnhancedCommand<Result<TResult>>> getResultCommand,
         object? icon = null,
-        DialogTone tone = DialogTone.Neutral) where TViewModel : class
+        DialogTone tone = DialogTone.Neutral,
+        DialogSize size = DialogSize.Auto) where TViewModel : class
     {
         var command = getResultCommand(viewModel);
         var captured = Maybe<TResult>.None;
@@ -232,7 +243,7 @@ public static class DialogExtensions
                 Cancel(closeable),
                 new Option(command.Text ?? "OK", command, new Settings { IsDefault = true }),
             ];
-        }, icon.ToMaybe(), tone);
+        }, icon.ToMaybe(), tone, size);
 
         subscription?.Dispose();
         return success ? captured : Maybe<TResult>.None;
@@ -243,14 +254,15 @@ public static class DialogExtensions
         string title,
         Func<TViewModel, IEnhancedCommand<Result<TResult>>> getResultCommand,
         object? icon = null,
-        DialogTone tone = DialogTone.Neutral) where TViewModel : class
-        => dialogService.ShowAndGetResult(viewModel, Observable.Return(title), getResultCommand, icon, tone);
+        DialogTone tone = DialogTone.Neutral,
+        DialogSize size = DialogSize.Auto) where TViewModel : class
+        => dialogService.ShowAndGetResult(viewModel, Observable.Return(title), getResultCommand, icon, tone, size);
 
     #endregion
 
     #region Specialized Dialogs
 
-    public static Task ShowMessage(this IDialog dialogService, string title, string text, string okText = "OK", object? icon = null, DialogTone tone = DialogTone.Information)
+    public static Task ShowMessage(this IDialog dialogService, string title, string text, string okText = "OK", object? icon = null, DialogTone tone = DialogTone.Information, DialogSize size = DialogSize.Auto)
     {
         var messageDialogViewModel = new MessageDialogViewModel(text);
 
@@ -263,10 +275,10 @@ public static class DialogExtensions
                 IsCancel = true
             };
             return [new Option(okText, command, settings)];
-        }, icon.ToMaybe(), tone);
+        }, icon.ToMaybe(), tone, size);
     }
 
-    public static async Task<Maybe<bool>> ShowConfirmation(this IDialog dialogService, string title, string text, string yesText = "Yes", string noText = "No", bool yesIsPrimary = true, object? icon = null, DialogTone tone = DialogTone.Neutral)
+    public static async Task<Maybe<bool>> ShowConfirmation(this IDialog dialogService, string title, string text, string yesText = "Yes", string noText = "No", bool yesIsPrimary = true, object? icon = null, DialogTone tone = DialogTone.Neutral, DialogSize size = DialogSize.Auto)
     {
         var result = false;
         var yesRole = yesIsPrimary ? OptionRole.Primary : OptionRole.Secondary;
@@ -288,7 +300,7 @@ public static class DialogExtensions
                     closeable.Close();
                 }).Enhance(), new Settings { Role = noRole })
             ];
-        }, icon.ToMaybe(), tone);
+        }, icon.ToMaybe(), tone, size);
 
         return show ? result : Maybe<bool>.None;
     }

--- a/src/Zafiro.Avalonia.Dialogs/IDialog.cs
+++ b/src/Zafiro.Avalonia.Dialogs/IDialog.cs
@@ -4,5 +4,5 @@ namespace Zafiro.Avalonia.Dialogs;
 
 public interface IDialog
 {
-    Task<bool> Show<TViewModel>(Maybe<TViewModel> viewModel, Maybe<IObservable<string>> title, Func<Maybe<TViewModel>, ICloseable, IEnumerable<IOption>> optionsFactory, Maybe<object> icon = default, DialogTone tone = DialogTone.Neutral);
+    Task<bool> Show<TViewModel>(Maybe<TViewModel> viewModel, Maybe<IObservable<string>> title, Func<Maybe<TViewModel>, ICloseable, IEnumerable<IOption>> optionsFactory, Maybe<object> icon = default, DialogTone tone = DialogTone.Neutral, DialogSize size = DialogSize.Auto);
 }

--- a/src/Zafiro.Avalonia.Dialogs/Implementations/AdornerDialog.cs
+++ b/src/Zafiro.Avalonia.Dialogs/Implementations/AdornerDialog.cs
@@ -48,7 +48,7 @@ public class AdornerDialog : IDialog, ICloseable
         });
     }
 
-    public async Task<bool> Show<TViewModel>(Maybe<TViewModel> viewModel, Maybe<IObservable<string>> title, Func<Maybe<TViewModel>, ICloseable, IEnumerable<IOption>> optionsFactory, Maybe<object> icon = default, DialogTone tone = DialogTone.Neutral)
+    public async Task<bool> Show<TViewModel>(Maybe<TViewModel> viewModel, Maybe<IObservable<string>> title, Func<Maybe<TViewModel>, ICloseable, IEnumerable<IOption>> optionsFactory, Maybe<object> icon = default, DialogTone tone = DialogTone.Neutral, DialogSize size = DialogSize.Auto)
     {
         if (optionsFactory == null) throw new ArgumentNullException(nameof(optionsFactory));
 
@@ -57,6 +57,8 @@ public class AdornerDialog : IDialog, ICloseable
             var completion = new TaskCompletionSource<bool>();
             var options = optionsFactory(viewModel, this);
 
+            var sizeHint = DialogSizeCalculator.Resolve(size);
+
             var dialog = new DialogViewContainer
             {
                 Content = new DialogControl()
@@ -64,7 +66,8 @@ public class AdornerDialog : IDialog, ICloseable
                     Content = viewModel.GetValueOrDefault(),
                     Options = options,
                     Icon = icon.GetValueOrDefault(),
-                    Tone = tone
+                    Tone = tone,
+                    SizeHint = sizeHint
                 },
                 Close = ReactiveCommand.Create(() => Dismiss()),
             };
@@ -83,6 +86,17 @@ public class AdornerDialog : IDialog, ICloseable
             dialog[!Layoutable.WidthProperty] = adornerLayer.Parent!
                 .GetObservable(Visual.BoundsProperty)
                 .Select(rect => rect.Width)
+                .ToBinding();
+
+            // Apply proportional constraints to inner content via ContentMaxWidth/ContentMaxHeight
+            var parentBoundsObs = adornerLayer.Parent!.GetObservable(Visual.BoundsProperty);
+
+            dialog[!DialogViewContainer.ContentMaxWidthProperty] = parentBoundsObs
+                .Select(rect => DialogSizeCalculator.Calculate(sizeHint, rect.Width, rect.Height).MaxWidth)
+                .ToBinding();
+
+            dialog[!DialogViewContainer.ContentMaxHeightProperty] = parentBoundsObs
+                .Select(rect => DialogSizeCalculator.Calculate(sizeHint, rect.Width, rect.Height).MaxHeight)
                 .ToBinding();
 
             adornerLayer.Children.Add(dialog);

--- a/src/Zafiro.Avalonia.Dialogs/Implementations/DesktopDialog.cs
+++ b/src/Zafiro.Avalonia.Dialogs/Implementations/DesktopDialog.cs
@@ -9,13 +9,15 @@ namespace Zafiro.Avalonia.Dialogs.Implementations;
 
 public class DesktopDialog : IDialog
 {
-    public async Task<bool> Show<TViewModel>(Maybe<TViewModel> viewModel, Maybe<IObservable<string>> title, Func<Maybe<TViewModel>, ICloseable, IEnumerable<IOption>> optionsFactory, Maybe<object> icon = default, DialogTone tone = DialogTone.Neutral)
+    public async Task<bool> Show<TViewModel>(Maybe<TViewModel> viewModel, Maybe<IObservable<string>> title, Func<Maybe<TViewModel>, ICloseable, IEnumerable<IOption>> optionsFactory, Maybe<object> icon = default, DialogTone tone = DialogTone.Neutral, DialogSize size = DialogSize.Auto)
     {
         if (optionsFactory == null) throw new ArgumentNullException(nameof(optionsFactory));
 
         var showTask = await Dispatcher.UIThread.InvokeAsync(async () =>
         {
             var mainWindow = ApplicationUtils.MainWindow().GetValueOrThrow("Cannot get the main window");
+
+            var sizeHint = DialogSizeCalculator.Resolve(size);
 
             var window = new Window
             {
@@ -24,6 +26,20 @@ public class DesktopDialog : IDialog
                 Icon = mainWindow.Icon,
                 SizeToContent = SizeToContent.WidthAndHeight,
             };
+
+            var screen = window.Screens.Primary ?? window.Screens.All.FirstOrDefault();
+            double availW = 1280, availH = 720;
+            if (screen != null)
+            {
+                var scaling = screen.Scaling;
+                availW = screen.WorkingArea.Width / scaling;
+                availH = screen.WorkingArea.Height / scaling;
+            }
+
+            var (minW, maxW, maxH) = DialogSizeCalculator.Calculate(sizeHint, availW, availH);
+            window.MinWidth = minW;
+            window.MaxWidth = maxW;
+            window.MaxHeight = maxH;
 
             using var titleSubscription = title.GetValueOrDefault(Observable.Never<string>())
                 .Subscribe(t => Dispatcher.UIThread.Post(() => window.Title = t ?? string.Empty));
@@ -36,7 +52,8 @@ public class DesktopDialog : IDialog
                 Content = viewModel.GetValueOrDefault(),
                 Options = options,
                 Icon = icon.GetValueOrDefault(),
-                Tone = tone
+                Tone = tone,
+                SizeHint = sizeHint
             };
 
             var result = await window.ShowDialog<bool?>(mainWindow).ConfigureAwait(false);

--- a/src/Zafiro.Avalonia.Dialogs/Implementations/StackedDesktopDialog.cs
+++ b/src/Zafiro.Avalonia.Dialogs/Implementations/StackedDesktopDialog.cs
@@ -13,7 +13,7 @@ public class StackedDesktopDialog : IDialog
     private static readonly Stack<DialogContext> DialogStack = new();
     private static IDisposable? titleSubscription;
 
-    public async Task<bool> Show<TViewModel>(Maybe<TViewModel> viewModel, Maybe<IObservable<string>> title, Func<Maybe<TViewModel>, ICloseable, IEnumerable<IOption>> optionsFactory, Maybe<object> icon = default, DialogTone tone = DialogTone.Neutral)
+    public async Task<bool> Show<TViewModel>(Maybe<TViewModel> viewModel, Maybe<IObservable<string>> title, Func<Maybe<TViewModel>, ICloseable, IEnumerable<IOption>> optionsFactory, Maybe<object> icon = default, DialogTone tone = DialogTone.Neutral, DialogSize size = DialogSize.Auto)
     {
         if (optionsFactory == null) throw new ArgumentNullException(nameof(optionsFactory));
 
@@ -26,7 +26,7 @@ public class StackedDesktopDialog : IDialog
             var options = optionsFactory(viewModel, closeable).ToList();
 
             // Create a context instance for the current dialog
-            var dialogContext = new DialogContext(viewModel.GetValueOrDefault(), title, options, completionSource, icon.GetValueOrDefault(), tone);
+            var dialogContext = new DialogContext(viewModel.GetValueOrDefault(), title, options, completionSource, icon.GetValueOrDefault(), tone, size);
 
             // Add the dialog to the stack
             DialogStack.Push(dialogContext);
@@ -39,10 +39,6 @@ public class StackedDesktopDialog : IDialog
                     WindowStartupLocation = WindowStartupLocation.CenterOwner,
                     Icon = mainWindow.Icon,
                     SizeToContent = SizeToContent.WidthAndHeight,
-                    MaxWidth = 800,
-                    MaxHeight = 700,
-                    MinWidth = 400,
-                    MinHeight = 300
                 };
 
                 // Handle the window closing event to complete every pending dialog
@@ -97,14 +93,29 @@ public class StackedDesktopDialog : IDialog
                 Content = dialogContext.ViewModel,
                 Options = dialogContext.Options,
                 Icon = dialogContext.Icon,
-                Tone = dialogContext.Tone
+                Tone = dialogContext.Tone,
+                SizeHint = DialogSizeCalculator.Resolve(dialogContext.Size)
             };
+
+            var screen = dialogWindow.Screens.Primary ?? dialogWindow.Screens.All.FirstOrDefault();
+            double availW = 1280, availH = 720;
+            if (screen != null)
+            {
+                var scaling = screen.Scaling;
+                availW = screen.WorkingArea.Width / scaling;
+                availH = screen.WorkingArea.Height / scaling;
+            }
+
+            var (minW, maxW, maxH) = DialogSizeCalculator.Calculate(DialogSizeCalculator.Resolve(dialogContext.Size), availW, availH);
+            dialogWindow.MinWidth = minW;
+            dialogWindow.MaxWidth = maxW;
+            dialogWindow.MaxHeight = maxH;
         }
     }
 
     private class DialogContext
     {
-        public DialogContext(object? viewModel, Maybe<IObservable<string>> title, IEnumerable<IOption> options, TaskCompletionSource<bool> completionSource, object? icon, DialogTone tone)
+        public DialogContext(object? viewModel, Maybe<IObservable<string>> title, IEnumerable<IOption> options, TaskCompletionSource<bool> completionSource, object? icon, DialogTone tone, DialogSize size)
         {
             ViewModel = viewModel;
             Title = title;
@@ -112,11 +123,13 @@ public class StackedDesktopDialog : IDialog
             CompletionSource = completionSource;
             Icon = icon;
             Tone = tone;
+            Size = size;
         }
 
         public object? ViewModel { get; }
         public object? Icon { get; }
         public DialogTone Tone { get; }
+        public DialogSize Size { get; }
         public Maybe<IObservable<string>> Title { get; }
         public IEnumerable<IOption> Options { get; }
         public TaskCompletionSource<bool> CompletionSource { get; }

--- a/src/Zafiro.Avalonia.Dialogs/Views/DialogControl.axaml
+++ b/src/Zafiro.Avalonia.Dialogs/Views/DialogControl.axaml
@@ -18,8 +18,9 @@
     </Design.PreviewWith>
 
     <Style Selector="DialogControl">
-        <Setter Property="Width" Value="448" />
-        <Setter Property="MaxHeight" Value="700" /> 
+        <Setter Property="MinWidth" Value="320" />
+        <Setter Property="MaxWidth" Value="500" />
+        <Setter Property="MaxHeight" Value="700" />
         <Setter Property="Template">
             <ControlTemplate>
                 <DockPanel VerticalSpacing="8">
@@ -97,5 +98,23 @@
                 </DockPanel>
             </ControlTemplate>
         </Setter>
+    </Style>
+
+    <!-- Size-class overrides -->
+    <Style Selector="DialogControl[SizeHint=Compact]">
+        <Setter Property="MinWidth" Value="280" />
+        <Setter Property="MaxWidth" Value="360" />
+    </Style>
+    <Style Selector="DialogControl[SizeHint=Standard]">
+        <Setter Property="MinWidth" Value="320" />
+        <Setter Property="MaxWidth" Value="500" />
+    </Style>
+    <Style Selector="DialogControl[SizeHint=Wide]">
+        <Setter Property="MinWidth" Value="400" />
+        <Setter Property="MaxWidth" Value="720" />
+    </Style>
+    <Style Selector="DialogControl[SizeHint=Full]">
+        <Setter Property="MinWidth" Value="400" />
+        <Setter Property="MaxWidth" Value="960" />
     </Style>
 </Styles>

--- a/src/Zafiro.Avalonia.Dialogs/Views/DialogControl.axaml.cs
+++ b/src/Zafiro.Avalonia.Dialogs/Views/DialogControl.axaml.cs
@@ -16,6 +16,9 @@ public class DialogControl : ContentControl
     public static readonly StyledProperty<DialogTone> ToneProperty = AvaloniaProperty.Register<DialogControl, DialogTone>(
         nameof(Tone), DialogTone.Neutral);
 
+    public static readonly StyledProperty<DialogSize> SizeHintProperty = AvaloniaProperty.Register<DialogControl, DialogSize>(
+        nameof(SizeHint), DialogSize.Auto);
+
     public static readonly StyledProperty<IEnumerable<IOption>?> OptionsProperty = AvaloniaProperty.Register<DialogControl, IEnumerable<IOption>?>(
         nameof(Options),
         []);
@@ -106,6 +109,12 @@ public class DialogControl : ContentControl
     {
         get => GetValue(ToneProperty);
         set => SetValue(ToneProperty, value);
+    }
+
+    public DialogSize SizeHint
+    {
+        get => GetValue(SizeHintProperty);
+        set => SetValue(SizeHintProperty, value);
     }
 
     public IEnumerable<IOption>? Options

--- a/src/Zafiro.Avalonia.Dialogs/Views/DialogViewContainer.axaml
+++ b/src/Zafiro.Avalonia.Dialogs/Views/DialogViewContainer.axaml
@@ -23,6 +23,8 @@
                             BorderThickness="1"
                             BorderBrush="Black"
                             Background="{DynamicResource SystemAltHighColor}"
+                            MaxWidth="{TemplateBinding ContentMaxWidth}"
+                            MaxHeight="{TemplateBinding ContentMaxHeight}"
                             HorizontalAlignment="Center"
                             VerticalAlignment="Center">
                         <StackPanel Spacing="20">

--- a/src/Zafiro.Avalonia.Dialogs/Views/DialogViewContainer.axaml.cs
+++ b/src/Zafiro.Avalonia.Dialogs/Views/DialogViewContainer.axaml.cs
@@ -12,6 +12,12 @@ public class DialogViewContainer : ContentControl
     public static readonly StyledProperty<ICommand> CloseProperty = AvaloniaProperty.Register<DialogViewContainer, ICommand>(
         nameof(Close));
 
+    public static readonly StyledProperty<double> ContentMaxWidthProperty = AvaloniaProperty.Register<DialogViewContainer, double>(
+        nameof(ContentMaxWidth), double.PositiveInfinity);
+
+    public static readonly StyledProperty<double> ContentMaxHeightProperty = AvaloniaProperty.Register<DialogViewContainer, double>(
+        nameof(ContentMaxHeight), double.PositiveInfinity);
+
     public string Title
     {
         get => GetValue(TitleProperty);
@@ -22,5 +28,17 @@ public class DialogViewContainer : ContentControl
     {
         get => GetValue(CloseProperty);
         set => SetValue(CloseProperty, value);
+    }
+
+    public double ContentMaxWidth
+    {
+        get => GetValue(ContentMaxWidthProperty);
+        set => SetValue(ContentMaxWidthProperty, value);
+    }
+
+    public double ContentMaxHeight
+    {
+        get => GetValue(ContentMaxHeightProperty);
+        set => SetValue(ContentMaxHeightProperty, value);
     }
 }

--- a/src/Zafiro.Avalonia.Dialogs/Views/MessageDialogView.axaml
+++ b/src/Zafiro.Avalonia.Dialogs/Views/MessageDialogView.axaml
@@ -9,7 +9,6 @@
              x:CompileBindings="True">
   <TextBlock TextAlignment="Center" 
              VerticalAlignment="Center" 
-             MaxWidth="400" 
              TextWrapping="Wrap" 
              Text="{Binding Message}" />
 </UserControl>


### PR DESCRIPTION
## Summary

Replace hardcoded `Width="448"` in `DialogControl` with proportional constraints that adapt to both content and screen size. Dialogs now size themselves optimally — short messages stay compact, forms get standard width, and large content can expand.

## Approach

A `DialogSize` enum (Auto/Compact/Standard/Wide/Full) is passed as an optional parameter to `IDialog.Show()`, defaulting to `Auto` (resolves to Standard). `DialogSizeCalculator` computes `MinWidth`/`MaxWidth`/`MaxHeight` as proportions of available screen space:

| Size | Width % | Range |
|------|---------|-------|
| Compact | 35% | 280–360px |
| Standard | 50% | 320–500px |
| Wide | 70% | 400–720px |
| Full | 90% | 400–960px |

The Window uses `SizeToContent=WidthAndHeight` so the dialog grows/shrinks to fit content within these guardrails.

## Key changes

- **IDialog + DialogExtensions**: `DialogSize size = DialogSize.Auto` parameter on all overloads
- **DesktopDialog**: proportional constraints from screen dimensions
- **StackedDesktopDialog**: per-dialog proportional sizing replacing hardcoded constraints
- **AdornerDialog**: reactive `ContentMaxWidth`/`ContentMaxHeight` from parent bounds (mobile/WASM)
- **DialogControl.axaml**: style selectors per `SizeHint` class, no more fixed width
- **MessageDialogView**: removed hardcoded `MaxWidth="400"` on TextBlock

## Verified visually via MCP

- Warning dialog (short text): 320px ✓
- Simple message: 448px (content-driven within constraints) ✓
- Big dialog (long text): 440px ✓
- Form dialog: 320px ✓

Default behavior is nearly identical to the previous 448px but now responsive.