### PR TITLE
feat(icons): add `text:` provider for emoji/glyph icons

### DIFF
--- a/docs/ai/concepts.md
+++ b/docs/ai/concepts.md
@@ -365,6 +365,21 @@ IconControlProviderRegistry.Register(new OptrisIconControlProvider(), asDefault:
 
 Icons are referenced by string keys: `"fa-home"` (FontAwesome), `"mdi-settings"` (Material Design).
 
+**Built-in providers**:
+
+| Prefix | Provider | Source assembly |
+|---|---|---|
+| `svg:` | `SvgIconControlProvider` — renders an SVG asset (`svg:/Assets/foo.svg` or `svg:OtherAsm/Assets/foo.svg`) | `Zafiro.Avalonia.Icons.Svg` |
+| `optris:` | `OptrisIconControlProvider` — Optris.Icons.Avalonia (FontAwesome, MaterialDesign, …) | `Zafiro.Avalonia.Icons.Optris` |
+| `text:` | `TextIconControlProvider` — renders any glyph/emoji/Unicode/ligature in a `TextBlock`. Honors `IconOptions.Fill` (→ Foreground) and `IconOptions.Size` (→ FontSize) | `Zafiro.Avalonia` (auto-registered) |
+
+```xml
+<!-- Glyph / emoji / monogram via the text: provider -->
+<EnhancedButton Icon="{Icon text:😘}" Content="Send" />
+<EnhancedButton Icon="{Icon text:★}"  Content="Star" />
+<EnhancedButton Icon="{Icon text:JS}" Content="Initials" />
+```
+
 **Evidence**: `TestApp/App.axaml.cs`, `HomeView.axaml`, `MinimalShell/Sections/*.axaml`.
 
 ---

--- a/src/Zafiro.Avalonia/Controls/EnhancedButton.axaml
+++ b/src/Zafiro.Avalonia/Controls/EnhancedButton.axaml
@@ -17,6 +17,8 @@
                 </EnhancedButton>
                 <EnhancedButton Icon="{Icon fa-wallet}" />
                 <EnhancedButton Icon="{Icon mdi-close}" HorizontalContentAlignment="Center" HorizontalAlignment="Stretch">Button with icon</EnhancedButton>
+                <EnhancedButton Icon="{Icon text:😘}">Emoji glyph</EnhancedButton>
+                <EnhancedButton Icon="{Icon text:★}">Star glyph</EnhancedButton>
                 <EnhancedButton Classes="Primary">Primary</EnhancedButton>
                 <EnhancedButton Classes="Secondary">Secondary</EnhancedButton>
                 <EnhancedButton Classes="Cancel">Cancel</EnhancedButton>

--- a/src/Zafiro.Avalonia/Icons/CoreIconsModuleInitializer.cs
+++ b/src/Zafiro.Avalonia/Icons/CoreIconsModuleInitializer.cs
@@ -1,0 +1,16 @@
+using System.Runtime.CompilerServices;
+
+namespace Zafiro.Avalonia.Icons;
+
+/// <summary>
+/// Module initializer that registers the icon providers shipped with the core
+/// Zafiro.Avalonia assembly (no external dependencies).
+/// </summary>
+internal static class CoreIconsModuleInitializer
+{
+    [ModuleInitializer]
+    internal static void Initialize()
+    {
+        IconControlProviderRegistry.Register(new TextIconControlProvider());
+    }
+}

--- a/src/Zafiro.Avalonia/Icons/TextIconControlProvider.cs
+++ b/src/Zafiro.Avalonia/Icons/TextIconControlProvider.cs
@@ -1,0 +1,38 @@
+using Avalonia.Layout;
+using Avalonia.Media;
+using Zafiro.Avalonia.Controls;
+
+namespace Zafiro.Avalonia.Icons;
+
+/// <summary>
+/// Provider that renders any text/glyph (emoji, Unicode character, font ligature, monogram, …)
+/// as a <see cref="TextBlock"/>. Use the <c>text:</c> prefix in <see cref="IIcon.Source"/>:
+/// <code>{Icon text:😘}</code> or <code>{Icon text:★}</code>.
+/// Honors <see cref="IconOptions.FillProperty"/> (mapped to Foreground) and
+/// <see cref="IconOptions.SizeProperty"/> (mapped to FontSize).
+/// </summary>
+public class TextIconControlProvider : IIconControlProvider
+{
+    public string Prefix => "text";
+
+    public Control? Create(IIcon icon, string valueWithoutPrefix)
+    {
+        if (string.IsNullOrEmpty(valueWithoutPrefix))
+        {
+            return null;
+        }
+
+        var textBlock = new TextBlock
+        {
+            Text = valueWithoutPrefix,
+            TextAlignment = TextAlignment.Center,
+            HorizontalAlignment = HorizontalAlignment.Center,
+            VerticalAlignment = VerticalAlignment.Center,
+        };
+
+        textBlock[!TextBlock.ForegroundProperty] = textBlock[!IconOptions.FillProperty];
+        textBlock[!TextBlock.FontSizeProperty] = textBlock[!IconOptions.SizeProperty];
+
+        return textBlock;
+    }
+}


### PR DESCRIPTION
## Idea

Hasta ahora `IIcon` se resolvía vía `prefix:value` contra los providers registrados (`svg:`, `optris:`, …), pero no había forma de meter por ese mismo pipeline un **glyph arbitrario** — un emoji, un carácter Unicode, una ligadura tipográfica o un monograma. Quien escribía `Icon="😘"` se saltaba el sistema de iconos (era contenido plano, sin `IconOptions`), y `{Icon 😘}` acababa cayendo en el `DefaultProvider` (Optris) y devolviendo el TextBlock de error.

Este PR añade un nuevo provider, `text:`, que renderiza el valor como un `TextBlock` y conecta sus propiedades visuales a `IconOptions` (`Fill → Foreground`, `Size → FontSize`), manteniendo el mismo contrato que los providers vectoriales.

```xml
<EnhancedButton Icon="{Icon text:😘}" Content="Send" />
<EnhancedButton Icon="{Icon text:★}"  Content="Star" />
<EnhancedButton Icon="{Icon text:JS}" Content="Initials" />
```

## Detalles relevantes para el futuro

- **Auto-registro vía `[ModuleInitializer]`** en el ensamblado core — mismo patrón que ya usa `Zafiro.Avalonia.Icons.Optris`. No hay que tocar `App.axaml.cs`.
- **Sin breaking changes**: el resto de prefijos y el `DefaultProvider` quedan intactos. El parser `Split(':', 2)` ya tolera valores con `:` dentro (`text:foo:bar` → value = `foo:bar`).
- **No se introduce auto-detección de emojis sin prefijo**: la resolución sigue teniendo un único punto (el prefijo) para que sea predecible. Si alguien quiere ese atajo, puede registrar `TextIconControlProvider` como `DefaultProvider`.
- **WASM**: la disponibilidad de emojis depende de la fuente del entorno; quien necesite garantías en navegador deberá embeber Noto Color Emoji o similar — pero ese riesgo no es nuevo, vale para cualquier `TextBlock`.
- Decisión deliberadamente fuera de alcance: rediseñar `IIcon` a una jerarquía tipada (`GlyphIcon`/`SvgIcon`/`PathIcon`/…). Este PR no la bloquea ni la prejuzga.

## Cambios

- **Nuevo** `src/Zafiro.Avalonia/Icons/TextIconControlProvider.cs`
- **Nuevo** `src/Zafiro.Avalonia/Icons/CoreIconsModuleInitializer.cs`
- Preview en `EnhancedButton.axaml` con dos ejemplos del nuevo provider
- Tabla de providers integrados añadida a `docs/ai/concepts.md`