### PR TITLE
Responsive ShellView: sidebar on wide, bottom strip on narrow

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -49,5 +49,7 @@
     <PackageVersion Include="xunit.v3" Version="3.2.2"/>
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.0"/>
     <PackageVersion Include="Zafiro.UI" Version="47.0.4"/>
+    <PackageVersion Include="Zafiro.Avalonia.Mcp.AppHost" Version="0.0.20"/>
+    <PackageVersion Include="AvaloniaUI.DiagnosticsSupport" Version="2.2.1"/>
   </ItemGroup>
 </Project>

--- a/samples/MinimalShell/MinimalShell.csproj
+++ b/samples/MinimalShell/MinimalShell.csproj
@@ -17,6 +17,7 @@
         <PackageReference Include="Optris.Icons.Avalonia.FontAwesome" />
         <PackageReference Include="Serilog.Sinks.Console" />
         <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="AvaloniaUI.DiagnosticsSupport" />
+        <PackageReference Include="Zafiro.Avalonia.Mcp.AppHost" />
     </ItemGroup>
 
     <ItemGroup>

--- a/samples/MinimalShell/Program.cs
+++ b/samples/MinimalShell/Program.cs
@@ -1,6 +1,7 @@
 using System;
 using Avalonia;
 using ReactiveUI.Avalonia;
+using Zafiro.Avalonia.Mcp.AppHost;
 
 namespace MinimalShell;
 
@@ -13,6 +14,7 @@ class Program
     public static AppBuilder BuildAvaloniaApp()
         => AppBuilder.Configure<App>()
             .UsePlatformDetect()
+            .UseMcpDiagnostics()
             .WithInterFont()
 #if DEBUG
             .WithDeveloperTools()

--- a/src/Zafiro.Avalonia/Controls/Shell/ShellView.axaml
+++ b/src/Zafiro.Avalonia/Controls/Shell/ShellView.axaml
@@ -5,6 +5,7 @@
              xmlns:shell="clr-namespace:Zafiro.UI.Shell;assembly=Zafiro.UI"
              xmlns:nav="clr-namespace:Zafiro.Avalonia.Controls.Navigation"
              xmlns:local="clr-namespace:Zafiro.Avalonia.Controls.Shell"
+             xmlns:zac="clr-namespace:Zafiro.Avalonia.Controls"
              mc:Ignorable="d" d:DesignWidth="900" d:DesignHeight="600"
              x:Class="Zafiro.Avalonia.Controls.Shell.ShellView" x:DataType="shell:IShell">
 
@@ -12,19 +13,48 @@
         <local:ShellDesign />
     </Design.DataContext>
 
-    <Grid ColumnDefinitions="Auto *">
-        <!-- Sidebar -->
-        <SectionStrip Grid.Column="0"
-                      Sections="{Binding Sections}"
-                      SelectedSection="{Binding SelectedSection.Value, Mode=TwoWay}" />
+    <UserControl.Styles>
+        <!-- Mobile-first defaults -->
+        <Style Selector="FlexPanel#ShellLayout">
+            <Setter Property="Direction" Value="ColumnReverse" />
+        </Style>
+        <Style Selector="zac|SectionStrip#ShellSectionStrip">
+            <Setter Property="Orientation" Value="Horizontal" />
+        </Style>
+    </UserControl.Styles>
 
-        <!-- Content -->
-        <Frame Grid.Column="1"
-               Content="{Binding SelectedSection.Value.Navigator.Content^}"
-               BackCommand="{Binding SelectedSection.Value.Navigator.Back}">
-            <Interaction.Behaviors>
-                <nav:AutoHeaderFooterBehavior />
-            </Interaction.Behaviors>
-        </Frame>
-    </Grid>
+    <!--
+        Responsive shell:
+        - Wide (>= 700): vertical SectionStrip on the left + content on the right.
+        - Narrow (< 700): content on top + horizontal SectionStrip at the bottom (mobile-style bar).
+    -->
+    <Border Container.Name="shell" Container.Sizing="Width">
+        <Border.Styles>
+            <ContainerQuery Name="shell" Query="min-width:700">
+                <Style Selector="FlexPanel#ShellLayout">
+                    <Setter Property="Direction" Value="Row" />
+                </Style>
+                <Style Selector="zac|SectionStrip#ShellSectionStrip">
+                    <Setter Property="Orientation" Value="Vertical" />
+                </Style>
+            </ContainerQuery>
+        </Border.Styles>
+
+        <FlexPanel x:Name="ShellLayout" AlignItems="Stretch">
+            <!-- Section navigation: bottom bar on mobile, sidebar on desktop -->
+            <zac:SectionStrip x:Name="ShellSectionStrip"
+                              FlexPanel.Shrink="0"
+                              Sections="{Binding Sections}"
+                              SelectedSection="{Binding SelectedSection.Value, Mode=TwoWay}" />
+
+            <!-- Content -->
+            <Frame FlexPanel.Grow="1"
+                   Content="{Binding SelectedSection.Value.Navigator.Content^}"
+                   BackCommand="{Binding SelectedSection.Value.Navigator.Back}">
+                <Interaction.Behaviors>
+                    <nav:AutoHeaderFooterBehavior />
+                </Interaction.Behaviors>
+            </Frame>
+        </FlexPanel>
+    </Border>
 </UserControl>


### PR DESCRIPTION
## Summary

`ShellView` now adapts to its container width using the canonical Zafiro `FlexPanel` + `ContainerQuery` mobile-first pattern:

- **Wide (≥ 700px)**: vertical `SectionStrip` as a sidebar on the left + content on the right (the previous behavior).
- **Narrow (< 700px)**: content on top + horizontal `SectionStrip` as a bottom navigation bar (mobile/tablet style).

This makes the default shell usable out-of-the-box on phones and narrow windows without any consumer code changes.

## Implementation notes

- Mobile-first defaults are declared via `UserControl.Styles` (not inline on the elements) so that the `ContainerQuery` overrides actually win — local values would otherwise beat style setters.
- Breakpoint is `min-width:700`, matching the natural threshold where a vertical SectionStrip stops being comfortable.
- The `Frame` content area is `FlexPanel.Grow="1"` and the `SectionStrip` is `FlexPanel.Shrink="0"`, so content fills available space and the nav bar keeps its intrinsic size in both orientations.

## Verification

Verified live via Zafiro.Avalonia.Mcp on the `MinimalShell` sample at both 900px (sidebar) and 500px (bottom bar). MCP wiring (`Zafiro.Avalonia.Mcp.AppHost` + `UseMcpDiagnostics()`) is included in `MinimalShell` so future shell behavior can be inspected the same way.