### PR TITLE
fix(SectionStrip): use TemplatedParent binding for true TwoWay SelectedSection (refs #232)

### DIFF
--- a/src/Zafiro.Avalonia/Controls/SectionStrip.axaml
+++ b/src/Zafiro.Avalonia/Controls/SectionStrip.axaml
@@ -193,7 +193,7 @@
                                 <Button.Flyout>
                                     <Flyout>
                                         <SectionStripListBox x:Name="OtherSections"
-                                                             SelectedItem="{TemplateBinding SelectedSection, Mode=TwoWay}"
+                                                             SelectedItem="{Binding SelectedSection, RelativeSource={RelativeSource TemplatedParent}, Mode=TwoWay}"
                                                              ItemContainerTheme="{Binding ItemContainerTheme, RelativeSource={RelativeSource TemplatedParent}, TargetNullValue={StaticResource {x:Type SectionStripItem}}}"
                                                              ItemTemplate="{Binding ItemTemplate, RelativeSource={RelativeSource TemplatedParent}, TargetNullValue={StaticResource VerticalItem}}"
                                                              ItemsSource="{Binding #VisibilityExposerBehavior.InvisibleItems}" />
@@ -209,7 +209,7 @@
                                                  Background="{TemplateBinding Background}"
                                                  ItemContainerTheme="{Binding ItemContainerTheme, RelativeSource={RelativeSource TemplatedParent}, TargetNullValue={StaticResource {x:Type SectionStripItem}}}"
                                                  ItemTemplate="{Binding ItemTemplate, RelativeSource={RelativeSource TemplatedParent}, TargetNullValue={StaticResource VerticalItem}}"
-                                                 SelectedItem="{TemplateBinding SelectedSection, Mode=TwoWay}"
+                                                 SelectedItem="{Binding SelectedSection, RelativeSource={RelativeSource TemplatedParent}, Mode=TwoWay}"
                                                  ItemsSource="{TemplateBinding FilteredSections}">
                                 <SectionStripListBox.ItemsPanel>
                                     <ItemsPanelTemplate>


### PR DESCRIPTION
Fixes the XAML side of #232 (empty `Frame` / sidebar clicks not propagating in `ShellView`).

## Root cause

`SectionStrip.axaml` bound the inner `SectionStripListBox.SelectedItem` to the templated parent's `SelectedSection` using `{TemplateBinding ..., Mode=TwoWay}`. In Avalonia's compiled-bindings pipeline, `TemplateBinding` is implicitly `OneWay` and the `Mode=TwoWay` modifier is silently ignored. So selection changes inside the strip never wrote back to `SelectedSection`, leaving the bound `Frame.Content` stuck on whatever the initial value was.

## Change

Both occurrences (overflow flyout list + main strip list) now use:

```xml
SelectedItem="{Binding SelectedSection, RelativeSource={RelativeSource TemplatedParent}, Mode=TwoWay}"
```

which honours the requested mode and round-trips selection in both directions.

## Note

This is one of two PRs needed to fully close #232. The companion PR in the [`Zafiro` repo](https://github.com/SuperJMN/Zafiro/pull/128) addresses the runtime side: removing `RxApp` references that broke under ReactiveUI 23 and making `Shell`'s initial section deterministic. Once that ships in a published `Zafiro.UI` version, this repo can bump the package pin.

## Validation

Verified end-to-end against `MinimalShell` with the companion fixes installed: Frame shows the Home view on startup, clicking sidebar items swaps content correctly.