### PR TITLE
Add hierarchical shell sections

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 *.user
 *.userosscache
 *.sln.docstates
+Directory.Build.local.props
 
 # User-specific files (MonoDevelop/Xamarin Studio)
 *.userprefs

--- a/Directory.Build.local.props.example
+++ b/Directory.Build.local.props.example
@@ -1,0 +1,6 @@
+<Project>
+  <PropertyGroup>
+    <UseLocalZafiroReferences>true</UseLocalZafiroReferences>
+    <ZafiroSourceRoot>../Zafiro</ZafiroSourceRoot>
+  </PropertyGroup>
+</Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,10 +1,14 @@
 <Project>
+  <Import Project="$(MSBuildThisFileDirectory)Directory.Build.local.props" Condition="Exists('$(MSBuildThisFileDirectory)Directory.Build.local.props')" />
   <PropertyGroup>
     <Nullable>enable</Nullable>
-    <UseLocalZafiroReferences Condition="'$(UseLocalZafiroReferences)' == ''">true</UseLocalZafiroReferences>
-    <UseLocalZafiroReferences Condition="'$(Configuration)' == 'Release'">false</UseLocalZafiroReferences>
+    <UseLocalZafiroReferences Condition="'$(UseLocalZafiroReferences)' == ''">false</UseLocalZafiroReferences>
+    <ZafiroSourceRoot Condition="'$(ZafiroSourceRoot)' == ''">$(MSBuildThisFileDirectory)../Zafiro</ZafiroSourceRoot>
   </PropertyGroup>
   <ItemGroup Condition="'$(MSBuildProjectName)' != 'Zafiro.Avalonia.Generators'">
     <Using Include="System.Reactive.Disposables.Fluent" />
   </ItemGroup>
+  <Target Name="ValidateLocalZafiroReferences" BeforeTargets="ResolveReferences" Condition="'$(UseLocalZafiroReferences)' == 'true' and !Exists('$(ZafiroSourceRoot)/src/Zafiro.UI/Zafiro.UI.csproj')">
+    <Error Text="UseLocalZafiroReferences=true but ZafiroSourceRoot '$(ZafiroSourceRoot)' does not contain src/Zafiro.UI/Zafiro.UI.csproj." />
+  </Target>
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
-    <AvaloniaVersion>12.0.0</AvaloniaVersion>
+    <AvaloniaVersion>12.0.4</AvaloniaVersion>
   </PropertyGroup>
   <ItemGroup>
     <!-- Avalonia 12 core -->
@@ -10,7 +10,7 @@
     <PackageVersion Include="Avalonia.Android" Version="$(AvaloniaVersion)"/>
     <PackageVersion Include="Avalonia.Browser" Version="$(AvaloniaVersion)"/>
     <PackageVersion Include="Avalonia.Controls.ColorPicker" Version="$(AvaloniaVersion)"/>
-    <PackageVersion Include="Avalonia.Controls.DataGrid" Version="$(AvaloniaVersion)"/>
+    <PackageVersion Include="Avalonia.Controls.DataGrid" Version="12.0.0"/>
     <PackageVersion Include="Avalonia.Desktop" Version="$(AvaloniaVersion)"/>
     <PackageVersion Include="Avalonia.Fonts.Inter" Version="$(AvaloniaVersion)"/>
     <PackageVersion Include="Avalonia.Headless.XUnit" Version="$(AvaloniaVersion)"/>
@@ -48,8 +48,8 @@
     <PackageVersion Include="Xamarin.AndroidX.Core.SplashScreen" Version="1.0.1.17"/>
     <PackageVersion Include="xunit.v3" Version="3.2.2"/>
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.0"/>
-    <PackageVersion Include="Zafiro.UI" Version="47.0.6"/>
-    <PackageVersion Include="Zafiro.Avalonia.Mcp.AppHost" Version="0.0.44"/>
+    <PackageVersion Include="Zafiro.UI" Version="47.1.0"/>
+    <PackageVersion Include="Zafiro.Avalonia.Mcp.AppHost" Version="0.0.61"/>
     <PackageVersion Include="AvaloniaUI.DiagnosticsSupport" Version="2.2.1"/>
   </ItemGroup>
 </Project>

--- a/WARP.md
+++ b/WARP.md
@@ -8,7 +8,7 @@ Tech stack
 
 - .NET 8 for libraries and samples; Android head targets net9.0-android
 - Avalonia 11.3.x, ReactiveUI
-- Submodule: libs/Zafiro points to the core Zafiro library repo (managed as a git submodule)
+- Zafiro core is developed in the sibling repo `../Zafiro`; CI and package builds consume published NuGet packages.
 
 Common commands
 
@@ -76,7 +76,7 @@ Azure Pipelines (CI/CD)
 - Triggers: push to master, PRs to master or any branch
 - Agent: ubuntu-latest
 - Steps summary
-  - Full checkout with submodules (fetchDepth: 0)
+  - Full checkout (fetchDepth: 0)
   - Install .NET 9 SDK (UseDotNet@2)
   - Install Android workload (dotnet workload install android)
     - Note: not strictly required for NuGet-only publishing, but kept for optional app release tasks
@@ -118,17 +118,16 @@ Source generators: Zafiro.Avalonia.Generators
                           ReferenceOutputAssembly="false" />
       </ItemGroup>
       ```
-    - The repo uses the UseLocalZafiroReferences switch to toggle between local ProjectReference (true) and NuGet PackageReference (false). This is already configured in Zafiro.Avalonia.Dialogs and samples/TestApp/TestApp.
+    - The repo uses the UseLocalZafiroReferences switch to toggle between a local ProjectReference to `$(ZafiroSourceRoot)` (true) and NuGet PackageReference (false). The default is false so CI and package builds use published packages.
 - Migration note
   - Zafiro.Avalonia no longer includes the generator in its package and no longer references it as an Analyzer. Any project that requires the generated registrations must explicitly reference Zafiro.Avalonia.Generators as shown above.
 
-Submodule: libs/Zafiro
+Local Zafiro development
 
-- This repo includes Zafiro as a git submodule in libs/Zafiro
-- To fetch and update:
-  - git submodule update --init --recursive
-  - To pull latest in submodule: (cd libs/Zafiro && git pull)
-  - After updating the submodule, commit the submodule pointer in this repository
+- This repo should not include Zafiro as a git submodule.
+- For local cross-repo iteration, keep Zafiro checked out next to this repo at `../Zafiro`, or set `ZafiroSourceRoot` explicitly.
+- Enable local references with `UseLocalZafiroReferences=true`, preferably from an ignored `Directory.Build.local.props`.
+- Use `Directory.Build.local.props.example` as the template for that ignored local file.
 
 Coding guidelines (high level)
 
@@ -199,11 +198,11 @@ When implementing new features
 - Model user intents as commands; derive canExecute from observable state with WhenAnyValue/WhenAnyChanged.
 - Return Result/Maybe and avoid throwing for non-exceptional control flow.
 - Keep UI glue reactive: avoid imperative handlers and "Subscribe" logic for business decisions.
-- If changes affect the Zafiro submodule, align with libs/Zafiro/WARP.md and prefer contributing upstream when appropriate.
+- If changes affect Zafiro core, make them in the sibling Zafiro repository and publish that package before publishing Zafiro.Avalonia.
 
 See also
 
-- libs/Zafiro/WARP.md for lower-level rules and architecture that apply to the Zafiro core submodule used by this repository.
+- ../Zafiro/WARP.md for lower-level rules and architecture that apply to the Zafiro core repository used during local development.
 
 Code examples
 
@@ -257,7 +256,7 @@ private static SlimWizard<(int result, string)> CreateWizard()
 
 - EnhancedCommand helpers (wrap ReactiveCommand with UX metadata)
 
-```cs path=/mnt/fast/Repos/SuperJMN-Zafiro/Zafiro.Avalonia/libs/Zafiro/src/Zafiro.UI/Commands/EnhancedCommand.cs start=7
+```cs path=/mnt/fast/Repos/Zafiro/src/Zafiro.UI/Commands/EnhancedCommand.cs start=7
 public static EnhancedCommand<T> Enhance<T>(this IEnhancedCommand<T> enhancedCommand, string? text = null, string? name = null, IObservable<bool>? canExecute = null)
 {
     return new EnhancedCommand<T>(ReactiveCommand.CreateFromObservable(enhancedCommand.Execute, canExecute ?? ((IReactiveCommand)enhancedCommand).CanExecute), text ?? enhancedCommand.Text, name ?? enhancedCommand.Name);
@@ -271,7 +270,7 @@ public static IEnhancedCommand<T, Q> Enhance<T, Q>(this ReactiveCommandBase<T, Q
 
 - Reactive adapters for Result pipelines
 
-```cs path=/mnt/fast/Repos/SuperJMN-Zafiro/Zafiro.Avalonia/libs/Zafiro/src/Zafiro/CSharpFunctionalExtensions/ReactiveResultMixin.cs start=25
+```cs path=/mnt/fast/Repos/Zafiro/src/Zafiro/CSharpFunctionalExtensions/ReactiveResultMixin.cs start=25
 public static IObservable<Result<K>> Map<T, K>(this IObservable<Result<T>> observable, Func<T, K> function)
 {
     return observable.Select(t => t.Map(function));
@@ -285,7 +284,7 @@ public static IObservable<Result<K>> Map<T, K>(this IObservable<Result<T>> obser
 
 - Jobs/Execution with cancellation and progress
 
-```cs path=/mnt/fast/Repos/SuperJMN-Zafiro/Zafiro.Avalonia/libs/Zafiro/src/Zafiro.UI/Jobs/Execution/StoppableExecution.cs start=6
+```cs path=/mnt/fast/Repos/Zafiro/src/Zafiro.UI/Jobs/Execution/StoppableExecution.cs start=6
 public class StoppableExecution : IExecution
 {
     public StoppableExecution(IObservable<Unit> observable, IObservable<IProgress> progress, Maybe<IObservable<bool>> canStart)
@@ -304,7 +303,7 @@ public class StoppableExecution : IExecution
 
 - Filesystem action with progress reporting
 
-```cs path=/mnt/fast/Repos/SuperJMN-Zafiro/Zafiro.Avalonia/libs/Zafiro/src/Zafiro.FileSystem.Actions/CopyFileAction.cs start=18
+```cs path=/mnt/fast/Repos/Zafiro/src/Zafiro.FileSystem.Actions/CopyFileAction.cs start=18
 public CopyFileAction(IData source, IMutableFile destination)
 {
     Source = source;

--- a/docs/ai/concepts.md
+++ b/docs/ai/concepts.md
@@ -50,7 +50,7 @@ var enhanced = save.Enhance("Save", name: "save-action");
 // enhanced.Text     → "Save"
 ```
 
-**Evidence**: `EnhancedCommand.cs` in libs/Zafiro, `Page1ViewModel.cs`, `DialogSampleViewModel.cs`, `WizardViewModel.cs`.
+**Evidence**: `EnhancedCommand.cs` in the sibling Zafiro repository, `Page1ViewModel.cs`, `DialogSampleViewModel.cs`, `WizardViewModel.cs`.
 
 ### Property Observation
 
@@ -158,9 +158,13 @@ public class HomeViewModel
 [Section(icon: "fa-gear", sortIndex: 1)]
 [SectionGroup("settings", "Settings")]
 public class SettingsViewModel { }
+
+[Section(icon: "fa-user", sortIndex: 0, ParentId = "Settings")]
+public class ProfileViewModel { }
 ```
 
 The source generator (`Zafiro.Avalonia.Generators`) discovers `[Section]`-decorated types and generates `AddAllSectionsFromAttributes()` extension method on `IServiceCollection`.
+`ParentId` creates hierarchical sections. Root sections are shown by the shell's primary `SectionStrip`; child levels are rendered automatically inside `ShellView`, and each section keeps its own scoped `INavigator`.
 
 ```csharp
 services.AddZafiroShell(logger: logger);

--- a/docs/ai/examples.md
+++ b/docs/ai/examples.md
@@ -41,7 +41,7 @@ public class App : Application
         services.AddZafiroShell(logger: logger);
         services.AddAllSectionsFromAttributes(logger);
         var provider = services.BuildServiceProvider();
-        var shell = provider.GetRequiredService<IShell>();
+        var shell = provider.GetRequiredService<IHierarchicalShell>();
         this.Connect(() => new ShellView(), _ => shell, () => new Window { Title = "App", Width = 900, Height = 600 });
         base.OnFrameworkInitializationCompleted();
     }

--- a/docs/ai/overview.md
+++ b/docs/ai/overview.md
@@ -56,7 +56,7 @@ public override void OnFrameworkInitializationCompleted()
     services.AddAllSectionsFromAttributes(logger);          // source-generated
 
     var provider = services.BuildServiceProvider();
-    var shell = provider.GetRequiredService<IShell>();
+    var shell = provider.GetRequiredService<IHierarchicalShell>();
 
     this.Connect(() => new ShellView(), _ => shell, () => new Window { Title = "App" });
     base.OnFrameworkInitializationCompleted();
@@ -80,7 +80,7 @@ public override void OnFrameworkInitializationCompleted()
 | Abstraction | Type | Purpose |
 |---|---|---|
 | `INavigator` | Service | Page navigation: `Go<T>()`, `GoBack()`, `SetInitialPage()` |
-| `IShell` | Service | Section-based app shell with sidebar |
+| `IShell` / `IHierarchicalShell` | Service | Section-based app shell; hierarchical shell adds section levels for `ShellView` |
 | `IDialog` | Service | Modal dialogs returning `Maybe<T>` |
 | `INotificationService` | Service | Push notifications from ViewModels |
 | `IEnhancedCommand<T>` | Command wrapper | `ReactiveCommand` + label + icon + IsBusy tracking |

--- a/samples/MinimalShell/App.axaml.cs
+++ b/samples/MinimalShell/App.axaml.cs
@@ -30,7 +30,7 @@ public class App : Application
         services.AddAllSectionsFromAttributes(logger);
 
         var provider = services.BuildServiceProvider();
-        var shell = provider.GetRequiredService<IShell>();
+        var shell = provider.GetRequiredService<IHierarchicalShell>();
 
         this.Connect(() => new ShellView(), _ => shell, () => new Window { Title = "Minimal Shell", Width = 900, Height = 600 });
 

--- a/samples/MinimalShell/MinimalShell.csproj
+++ b/samples/MinimalShell/MinimalShell.csproj
@@ -24,6 +24,7 @@
         <ProjectReference Include="../../src/Zafiro.Avalonia/Zafiro.Avalonia.csproj" />
         <ProjectReference Include="../../src/Zafiro.Avalonia.Generators/Zafiro.Avalonia.Generators.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
         <ProjectReference Include="../../src/Zafiro.Avalonia.Icons.Optris/Zafiro.Avalonia.Icons.Optris.csproj" />
-        <PackageReference Include="Zafiro.UI" />
+        <ProjectReference Include="$(ZafiroSourceRoot)/src/Zafiro.UI/Zafiro.UI.csproj" Condition="'$(UseLocalZafiroReferences)' == 'true'" />
+        <PackageReference Include="Zafiro.UI" Condition="'$(UseLocalZafiroReferences)' != 'true'" />
     </ItemGroup>
 </Project>

--- a/samples/MinimalShell/Sections/AboutViewModel.cs
+++ b/samples/MinimalShell/Sections/AboutViewModel.cs
@@ -4,7 +4,7 @@ using Zafiro.UI.Shell.Utils;
 
 namespace MinimalShell.Sections;
 
-[Section(icon: "fa-circle-info", sortIndex: 3)]
+[Section(icon: "fa-circle-info", sortIndex: 1, ParentId = "Settings")]
 public class AboutViewModel : IHaveHeader
 {
     public IObservable<object> Header => Observable.Return<object>("About This App");

--- a/samples/MinimalShell/Sections/MasterDetailsViewModel.cs
+++ b/samples/MinimalShell/Sections/MasterDetailsViewModel.cs
@@ -3,7 +3,7 @@ using Zafiro.UI.Shell.Utils;
 
 namespace MinimalShell.Sections;
 
-[Section(name: "MasterDetails", icon: "fa-circle-info", sortIndex: 4)]
+[Section(name: "MasterDetails", icon: "fa-circle-info", sortIndex: 0, ParentId = "Profile")]
 public class MasterDetailsViewModel : ReactiveObject
 {
     private MasterDetailsItem? selectedItem;

--- a/samples/MinimalShell/Sections/ProfileViewModel.cs
+++ b/samples/MinimalShell/Sections/ProfileViewModel.cs
@@ -2,7 +2,7 @@ using Zafiro.UI.Shell.Utils;
 
 namespace MinimalShell.Sections;
 
-[Section(icon: "fa-user", sortIndex: 2)]
+[Section(icon: "fa-user", sortIndex: 0, ParentId = "Settings")]
 public class ProfileViewModel
 {
     public string UserName => "Jane Doe";

--- a/samples/TestApp/TestApp.Desktop/TestApp.Desktop.csproj
+++ b/samples/TestApp/TestApp.Desktop/TestApp.Desktop.csproj
@@ -15,6 +15,8 @@
     </ItemGroup>
     <ItemGroup>
         <PackageReference Include="Avalonia.Desktop"/>
+        <PackageReference Include="Microsoft.CodeAnalysis.Common" VersionOverride="4.11.0" PrivateAssets="all"/>
+        <PackageReference Include="Microsoft.CodeAnalysis.CSharp" VersionOverride="4.11.0" PrivateAssets="all"/>
         <PackageReference Include="ReactiveUI.Avalonia"/>
         <PackageReference Include="Zafiro.Avalonia.Mcp.AppHost"/>
     </ItemGroup>

--- a/samples/TestApp/TestApp/CompositionRoot.cs
+++ b/samples/TestApp/TestApp/CompositionRoot.cs
@@ -1,4 +1,3 @@
-using ReactiveUI;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -10,6 +9,7 @@ using ReactiveUI;
 using Serilog;
 using TestApp.Samples;
 using TestApp.Samples.Navigation;
+using TestApp.Samples.Shell.Hierarchy;
 using TestApp.Shell;
 using Zafiro.Avalonia;
 using Zafiro.Avalonia.Dialogs;
@@ -88,6 +88,11 @@ public static class CompositionRoot
             var icon = sectionAttr.Icon ?? "fa-window-maximize";
 
             var groupAttr = type.GetCustomAttribute<SectionGroupAttribute>();
+            if (groupAttr?.Key == HierarchicalShellSampleViewModel.DemoGroupKey)
+            {
+                continue;
+            }
+
             var category = groupAttr?.FriendlyName ?? groupAttr?.Key ?? "General";
 
             var contractType = sectionAttr.ContractType ?? type;

--- a/samples/TestApp/TestApp/Samples/Shell/Hierarchy/HierarchicalShellSampleView.axaml
+++ b/samples/TestApp/TestApp/Samples/Shell/Hierarchy/HierarchicalShellSampleView.axaml
@@ -1,0 +1,10 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:hierarchy="clr-namespace:TestApp.Samples.Shell.Hierarchy"
+             mc:Ignorable="d" d:DesignWidth="900" d:DesignHeight="650"
+             x:Class="TestApp.Samples.Shell.Hierarchy.HierarchicalShellSampleView"
+             x:DataType="hierarchy:HierarchicalShellSampleViewModel">
+    <ShellView DataContext="{Binding Shell}" />
+</UserControl>

--- a/samples/TestApp/TestApp/Samples/Shell/Hierarchy/HierarchicalShellSampleView.axaml.cs
+++ b/samples/TestApp/TestApp/Samples/Shell/Hierarchy/HierarchicalShellSampleView.axaml.cs
@@ -1,0 +1,11 @@
+using Avalonia.Controls;
+
+namespace TestApp.Samples.Shell.Hierarchy;
+
+public partial class HierarchicalShellSampleView : UserControl
+{
+    public HierarchicalShellSampleView()
+    {
+        InitializeComponent();
+    }
+}

--- a/samples/TestApp/TestApp/Samples/Shell/Hierarchy/HierarchicalShellSampleViewModel.cs
+++ b/samples/TestApp/TestApp/Samples/Shell/Hierarchy/HierarchicalShellSampleViewModel.cs
@@ -1,0 +1,39 @@
+using System;
+using Microsoft.Extensions.DependencyInjection;
+using Zafiro.UI.Navigation;
+using Zafiro.UI.Shell;
+using Zafiro.UI.Shell.Utils;
+using TestApp.Samples.Shell.Hierarchy.Sections;
+
+namespace TestApp.Samples.Shell.Hierarchy;
+
+[Section(name: "Hierarchical Shell", icon: "mdi-sitemap", sortIndex: 0)]
+[SectionGroup("shell", "Shell")]
+public sealed class HierarchicalShellSampleViewModel : IDisposable
+{
+    public const string DemoGroupKey = "hierarchical-shell-demo";
+
+    private readonly ServiceProvider provider;
+
+    public HierarchicalShellSampleViewModel()
+    {
+        var services = new ServiceCollection();
+        services.AddZafiroShell();
+        services.AddSectionsFromAttributes(typeof(HierarchicalShellSampleViewModel).Assembly, IsDemoSection);
+
+        provider = services.BuildServiceProvider();
+        Shell = provider.GetRequiredService<IHierarchicalShell>();
+    }
+
+    public IHierarchicalShell Shell { get; }
+
+    public void Dispose()
+    {
+        provider.Dispose();
+    }
+
+    private static bool IsDemoSection(Type type)
+    {
+        return type.Namespace == typeof(WorkspaceViewModel).Namespace;
+    }
+}

--- a/samples/TestApp/TestApp/Samples/Shell/Hierarchy/Sections/ActiveCustomersView.axaml
+++ b/samples/TestApp/TestApp/Samples/Shell/Hierarchy/Sections/ActiveCustomersView.axaml
@@ -1,0 +1,12 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:sections="clr-namespace:TestApp.Samples.Shell.Hierarchy.Sections"
+             mc:Ignorable="d" d:DesignWidth="700" d:DesignHeight="450"
+             x:Class="TestApp.Samples.Shell.Hierarchy.Sections.ActiveCustomersView"
+             x:DataType="sections:ActiveCustomersViewModel">
+    <HeaderedContainer Header="{Binding Title}">
+        <TextBlock Text="{Binding Summary}" TextWrapping="Wrap" />
+    </HeaderedContainer>
+</UserControl>

--- a/samples/TestApp/TestApp/Samples/Shell/Hierarchy/Sections/ActiveCustomersView.axaml.cs
+++ b/samples/TestApp/TestApp/Samples/Shell/Hierarchy/Sections/ActiveCustomersView.axaml.cs
@@ -1,0 +1,11 @@
+using Avalonia.Controls;
+
+namespace TestApp.Samples.Shell.Hierarchy.Sections;
+
+public partial class ActiveCustomersView : UserControl
+{
+    public ActiveCustomersView()
+    {
+        InitializeComponent();
+    }
+}

--- a/samples/TestApp/TestApp/Samples/Shell/Hierarchy/Sections/CustomersView.axaml
+++ b/samples/TestApp/TestApp/Samples/Shell/Hierarchy/Sections/CustomersView.axaml
@@ -1,0 +1,12 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:sections="clr-namespace:TestApp.Samples.Shell.Hierarchy.Sections"
+             mc:Ignorable="d" d:DesignWidth="700" d:DesignHeight="450"
+             x:Class="TestApp.Samples.Shell.Hierarchy.Sections.CustomersView"
+             x:DataType="sections:CustomersViewModel">
+    <HeaderedContainer Header="{Binding Title}">
+        <TextBlock Text="{Binding Summary}" TextWrapping="Wrap" />
+    </HeaderedContainer>
+</UserControl>

--- a/samples/TestApp/TestApp/Samples/Shell/Hierarchy/Sections/CustomersView.axaml.cs
+++ b/samples/TestApp/TestApp/Samples/Shell/Hierarchy/Sections/CustomersView.axaml.cs
@@ -1,0 +1,11 @@
+using Avalonia.Controls;
+
+namespace TestApp.Samples.Shell.Hierarchy.Sections;
+
+public partial class CustomersView : UserControl
+{
+    public CustomersView()
+    {
+        InitializeComponent();
+    }
+}

--- a/samples/TestApp/TestApp/Samples/Shell/Hierarchy/Sections/ForecastView.axaml
+++ b/samples/TestApp/TestApp/Samples/Shell/Hierarchy/Sections/ForecastView.axaml
@@ -1,0 +1,12 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:sections="clr-namespace:TestApp.Samples.Shell.Hierarchy.Sections"
+             mc:Ignorable="d" d:DesignWidth="700" d:DesignHeight="450"
+             x:Class="TestApp.Samples.Shell.Hierarchy.Sections.ForecastView"
+             x:DataType="sections:ForecastViewModel">
+    <HeaderedContainer Header="{Binding Title}">
+        <TextBlock Text="{Binding Summary}" TextWrapping="Wrap" />
+    </HeaderedContainer>
+</UserControl>

--- a/samples/TestApp/TestApp/Samples/Shell/Hierarchy/Sections/ForecastView.axaml.cs
+++ b/samples/TestApp/TestApp/Samples/Shell/Hierarchy/Sections/ForecastView.axaml.cs
@@ -1,0 +1,11 @@
+using Avalonia.Controls;
+
+namespace TestApp.Samples.Shell.Hierarchy.Sections;
+
+public partial class ForecastView : UserControl
+{
+    public ForecastView()
+    {
+        InitializeComponent();
+    }
+}

--- a/samples/TestApp/TestApp/Samples/Shell/Hierarchy/Sections/HierarchicalDemoSections.cs
+++ b/samples/TestApp/TestApp/Samples/Shell/Hierarchy/Sections/HierarchicalDemoSections.cs
@@ -1,0 +1,90 @@
+using TestApp.Samples.Shell.Hierarchy;
+using Zafiro.UI.Shell.Utils;
+
+namespace TestApp.Samples.Shell.Hierarchy.Sections;
+
+public abstract class HierarchicalDemoPage(string title, string summary)
+{
+    public string Title { get; } = title;
+    public string Summary { get; } = summary;
+}
+
+[Section("workspace", "mdi-view-dashboard", 0, FriendlyName = "Workspace")]
+[SectionGroup(HierarchicalShellSampleViewModel.DemoGroupKey, "Hierarchical Shell Demo")]
+public class WorkspaceViewModel : HierarchicalDemoPage
+{
+    public WorkspaceViewModel()
+        : base("Workspace", "Operational area for day-to-day work.")
+    {
+    }
+}
+
+[Section("reports", "mdi-chart-box-outline", 1, FriendlyName = "Reports")]
+[SectionGroup(HierarchicalShellSampleViewModel.DemoGroupKey, "Hierarchical Shell Demo")]
+public class ReportsViewModel : HierarchicalDemoPage
+{
+    public ReportsViewModel()
+        : base("Reports", "Reporting area with its own navigation scope.")
+    {
+    }
+}
+
+[Section("customers", "mdi-account-group", 0, FriendlyName = "Customers", ParentId = "workspace")]
+[SectionGroup(HierarchicalShellSampleViewModel.DemoGroupKey, "Hierarchical Shell Demo")]
+public class CustomersViewModel : HierarchicalDemoPage
+{
+    public CustomersViewModel()
+        : base("Customers", "Customer operations within the workspace area.")
+    {
+    }
+}
+
+[Section("security", "mdi-shield-key", 1, FriendlyName = "Security", ParentId = "workspace")]
+[SectionGroup(HierarchicalShellSampleViewModel.DemoGroupKey, "Hierarchical Shell Demo")]
+public class SecurityViewModel : HierarchicalDemoPage
+{
+    public SecurityViewModel()
+        : base("Security", "Access control section under workspace.")
+    {
+    }
+}
+
+[Section("active-customers", "mdi-account-check", 0, FriendlyName = "Active", ParentId = "customers")]
+[SectionGroup(HierarchicalShellSampleViewModel.DemoGroupKey, "Hierarchical Shell Demo")]
+public class ActiveCustomersViewModel : HierarchicalDemoPage
+{
+    public ActiveCustomersViewModel()
+        : base("Active customers", "Leaf section with an independent navigator.")
+    {
+    }
+}
+
+[Section("segments", "mdi-chart-donut", 1, FriendlyName = "Segments", ParentId = "customers")]
+[SectionGroup(HierarchicalShellSampleViewModel.DemoGroupKey, "Hierarchical Shell Demo")]
+public class SegmentsViewModel : HierarchicalDemoPage
+{
+    public SegmentsViewModel()
+        : base("Segments", "Sibling leaf section under customers.")
+    {
+    }
+}
+
+[Section("sales", "mdi-chart-line", 0, FriendlyName = "Sales", ParentId = "reports")]
+[SectionGroup(HierarchicalShellSampleViewModel.DemoGroupKey, "Hierarchical Shell Demo")]
+public class SalesViewModel : HierarchicalDemoPage
+{
+    public SalesViewModel()
+        : base("Sales", "Reports branch leaf section.")
+    {
+    }
+}
+
+[Section("forecast", "mdi-calendar-clock", 1, FriendlyName = "Forecast", ParentId = "reports")]
+[SectionGroup(HierarchicalShellSampleViewModel.DemoGroupKey, "Hierarchical Shell Demo")]
+public class ForecastViewModel : HierarchicalDemoPage
+{
+    public ForecastViewModel()
+        : base("Forecast", "Another reports branch leaf section.")
+    {
+    }
+}

--- a/samples/TestApp/TestApp/Samples/Shell/Hierarchy/Sections/ReportsView.axaml
+++ b/samples/TestApp/TestApp/Samples/Shell/Hierarchy/Sections/ReportsView.axaml
@@ -1,0 +1,12 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:sections="clr-namespace:TestApp.Samples.Shell.Hierarchy.Sections"
+             mc:Ignorable="d" d:DesignWidth="700" d:DesignHeight="450"
+             x:Class="TestApp.Samples.Shell.Hierarchy.Sections.ReportsView"
+             x:DataType="sections:ReportsViewModel">
+    <HeaderedContainer Header="{Binding Title}">
+        <TextBlock Text="{Binding Summary}" TextWrapping="Wrap" />
+    </HeaderedContainer>
+</UserControl>

--- a/samples/TestApp/TestApp/Samples/Shell/Hierarchy/Sections/ReportsView.axaml.cs
+++ b/samples/TestApp/TestApp/Samples/Shell/Hierarchy/Sections/ReportsView.axaml.cs
@@ -1,0 +1,11 @@
+using Avalonia.Controls;
+
+namespace TestApp.Samples.Shell.Hierarchy.Sections;
+
+public partial class ReportsView : UserControl
+{
+    public ReportsView()
+    {
+        InitializeComponent();
+    }
+}

--- a/samples/TestApp/TestApp/Samples/Shell/Hierarchy/Sections/SalesView.axaml
+++ b/samples/TestApp/TestApp/Samples/Shell/Hierarchy/Sections/SalesView.axaml
@@ -1,0 +1,12 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:sections="clr-namespace:TestApp.Samples.Shell.Hierarchy.Sections"
+             mc:Ignorable="d" d:DesignWidth="700" d:DesignHeight="450"
+             x:Class="TestApp.Samples.Shell.Hierarchy.Sections.SalesView"
+             x:DataType="sections:SalesViewModel">
+    <HeaderedContainer Header="{Binding Title}">
+        <TextBlock Text="{Binding Summary}" TextWrapping="Wrap" />
+    </HeaderedContainer>
+</UserControl>

--- a/samples/TestApp/TestApp/Samples/Shell/Hierarchy/Sections/SalesView.axaml.cs
+++ b/samples/TestApp/TestApp/Samples/Shell/Hierarchy/Sections/SalesView.axaml.cs
@@ -1,0 +1,11 @@
+using Avalonia.Controls;
+
+namespace TestApp.Samples.Shell.Hierarchy.Sections;
+
+public partial class SalesView : UserControl
+{
+    public SalesView()
+    {
+        InitializeComponent();
+    }
+}

--- a/samples/TestApp/TestApp/Samples/Shell/Hierarchy/Sections/SecurityView.axaml
+++ b/samples/TestApp/TestApp/Samples/Shell/Hierarchy/Sections/SecurityView.axaml
@@ -1,0 +1,12 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:sections="clr-namespace:TestApp.Samples.Shell.Hierarchy.Sections"
+             mc:Ignorable="d" d:DesignWidth="700" d:DesignHeight="450"
+             x:Class="TestApp.Samples.Shell.Hierarchy.Sections.SecurityView"
+             x:DataType="sections:SecurityViewModel">
+    <HeaderedContainer Header="{Binding Title}">
+        <TextBlock Text="{Binding Summary}" TextWrapping="Wrap" />
+    </HeaderedContainer>
+</UserControl>

--- a/samples/TestApp/TestApp/Samples/Shell/Hierarchy/Sections/SecurityView.axaml.cs
+++ b/samples/TestApp/TestApp/Samples/Shell/Hierarchy/Sections/SecurityView.axaml.cs
@@ -1,0 +1,11 @@
+using Avalonia.Controls;
+
+namespace TestApp.Samples.Shell.Hierarchy.Sections;
+
+public partial class SecurityView : UserControl
+{
+    public SecurityView()
+    {
+        InitializeComponent();
+    }
+}

--- a/samples/TestApp/TestApp/Samples/Shell/Hierarchy/Sections/SegmentsView.axaml
+++ b/samples/TestApp/TestApp/Samples/Shell/Hierarchy/Sections/SegmentsView.axaml
@@ -1,0 +1,12 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:sections="clr-namespace:TestApp.Samples.Shell.Hierarchy.Sections"
+             mc:Ignorable="d" d:DesignWidth="700" d:DesignHeight="450"
+             x:Class="TestApp.Samples.Shell.Hierarchy.Sections.SegmentsView"
+             x:DataType="sections:SegmentsViewModel">
+    <HeaderedContainer Header="{Binding Title}">
+        <TextBlock Text="{Binding Summary}" TextWrapping="Wrap" />
+    </HeaderedContainer>
+</UserControl>

--- a/samples/TestApp/TestApp/Samples/Shell/Hierarchy/Sections/SegmentsView.axaml.cs
+++ b/samples/TestApp/TestApp/Samples/Shell/Hierarchy/Sections/SegmentsView.axaml.cs
@@ -1,0 +1,11 @@
+using Avalonia.Controls;
+
+namespace TestApp.Samples.Shell.Hierarchy.Sections;
+
+public partial class SegmentsView : UserControl
+{
+    public SegmentsView()
+    {
+        InitializeComponent();
+    }
+}

--- a/samples/TestApp/TestApp/Samples/Shell/Hierarchy/Sections/WorkspaceView.axaml
+++ b/samples/TestApp/TestApp/Samples/Shell/Hierarchy/Sections/WorkspaceView.axaml
@@ -1,0 +1,12 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:sections="clr-namespace:TestApp.Samples.Shell.Hierarchy.Sections"
+             mc:Ignorable="d" d:DesignWidth="700" d:DesignHeight="450"
+             x:Class="TestApp.Samples.Shell.Hierarchy.Sections.WorkspaceView"
+             x:DataType="sections:WorkspaceViewModel">
+    <HeaderedContainer Header="{Binding Title}">
+        <TextBlock Text="{Binding Summary}" TextWrapping="Wrap" />
+    </HeaderedContainer>
+</UserControl>

--- a/samples/TestApp/TestApp/Samples/Shell/Hierarchy/Sections/WorkspaceView.axaml.cs
+++ b/samples/TestApp/TestApp/Samples/Shell/Hierarchy/Sections/WorkspaceView.axaml.cs
@@ -1,0 +1,11 @@
+using Avalonia.Controls;
+
+namespace TestApp.Samples.Shell.Hierarchy.Sections;
+
+public partial class WorkspaceView : UserControl
+{
+    public WorkspaceView()
+    {
+        InitializeComponent();
+    }
+}

--- a/samples/TestApp/TestApp/TestApp.csproj
+++ b/samples/TestApp/TestApp/TestApp.csproj
@@ -33,7 +33,8 @@
         <ProjectReference Include="..\..\..\src\Zafiro.Avalonia.Icons.Optris\Zafiro.Avalonia.Icons.Optris.csproj"/>
         <ProjectReference Include="..\..\..\src\Zafiro.Avalonia.Icons.Svg\Zafiro.Avalonia.Icons.Svg.csproj"/>
 
-        <PackageReference Include="Zafiro.UI"/>
+        <ProjectReference Include="$(ZafiroSourceRoot)/src/Zafiro.UI/Zafiro.UI.csproj" Condition="'$(UseLocalZafiroReferences)' == 'true'" />
+        <PackageReference Include="Zafiro.UI" Condition="'$(UseLocalZafiroReferences)' != 'true'" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Zafiro.Avalonia.Generators/SectionsRegistrationGenerator.cs
+++ b/src/Zafiro.Avalonia.Generators/SectionsRegistrationGenerator.cs
@@ -96,6 +96,17 @@ public sealed class SectionsRegistrationGenerator : IIncrementalGenerator
                     sb.Append(Escape(s.shortName));
                     sb.Append("\"");
                 }
+                else if (s.parentId is not null)
+                {
+                    sb.Append(", shortName: null");
+                }
+
+                if (s.parentId is not null)
+                {
+                    sb.Append(", parentId: \"");
+                    sb.Append(Escape(s.parentId));
+                    sb.Append("\"");
+                }
 
                 sb.Append(");");
                 sb.AppendLine();
@@ -134,7 +145,7 @@ public sealed class SectionsRegistrationGenerator : IIncrementalGenerator
 
     private static
         IEnumerable<(string implFqn, string contractFqn, int sortIndex, string name, string friendlyName, string?
-            shortName, string? icon, string? groupKey, string? groupFriendlyName)> FindAnnotatedSections(
+            shortName, string? parentId, string? icon, string? groupKey, string? groupFriendlyName)> FindAnnotatedSections(
             Compilation compilation, SourceProductionContext context)
     {
         var attr = compilation.GetTypeByMetadataName("Zafiro.UI.Shell.Utils.SectionAttribute");
@@ -178,6 +189,7 @@ public sealed class SectionsRegistrationGenerator : IIncrementalGenerator
             string? explicitName = null;
             string? explicitFriendlyName = null;
             string? shortName = null;
+            string? parentId = null;
             var sortIndex = 0;
             ITypeSymbol? contract = null;
 
@@ -189,6 +201,7 @@ public sealed class SectionsRegistrationGenerator : IIncrementalGenerator
 
             explicitFriendlyName = GetNamedString(sectionAttr, "FriendlyName");
             shortName = GetNamedString(sectionAttr, "ShortName");
+            parentId = GetNamedString(sectionAttr, "ParentId");
 
             if (sectionCtorArgs.Length >= 2 && sectionCtorArgs[1].Value is string iconStr)
             {
@@ -216,7 +229,7 @@ public sealed class SectionsRegistrationGenerator : IIncrementalGenerator
             var name = explicitName ?? defaultName;
             var friendlyName = explicitFriendlyName ?? explicitName ?? defaultName;
 
-            yield return (implFqn, contractFqn, sortIndex, name, friendlyName, shortName, icon, groupKey,
+            yield return (implFqn, contractFqn, sortIndex, name, friendlyName, shortName, parentId, icon, groupKey,
                 groupFriendlyName);
         }
     }

--- a/src/Zafiro.Avalonia/Controls/Shell/ShellDesign.cs
+++ b/src/Zafiro.Avalonia/Controls/Shell/ShellDesign.cs
@@ -3,19 +3,23 @@ using Zafiro.UI.Shell;
 
 namespace Zafiro.Avalonia.Controls.Shell;
 
-public class ShellDesign : IShell
+public class ShellDesign : IHierarchicalShell
 {
     public ShellDesign()
     {
-        var sections = new ISection[]
-        {
-            new SimpleSection { Id = "Home", FriendlyName = "Home", Icon = new Icon { Source = "fa-home" } },
-            new SimpleSection { Id = "Settings", FriendlyName = "Settings", Icon = new Icon { Source = "fa-gear" } },
-            new SimpleSection { Id = "Profile", FriendlyName = "Profile", Icon = new Icon { Source = "fa-user" } },
-        };
+        var home = new SimpleSection { Id = "Home", FriendlyName = "Home", Icon = new Icon { Source = "fa-home" } };
+        var settings = new SimpleSection { Id = "Settings", FriendlyName = "Settings", Icon = new Icon { Source = "fa-gear" } };
+        var profile = new SimpleSection { Id = "Profile", ParentId = "Settings", FriendlyName = "Profile", Icon = new Icon { Source = "fa-user" } };
+        var preferences = new SimpleSection { Id = "Preferences", ParentId = "Settings", FriendlyName = "Preferences", Icon = new Icon { Source = "fa-sliders" } };
+        var sections = new ISection[] { home, settings, profile, preferences };
 
         Sections = sections;
-        SelectedSection = new global::Reactive.Bindings.ReactiveProperty<ISection>(sections[0]);
+        SelectedSection = new global::Reactive.Bindings.ReactiveProperty<ISection>(profile);
+        SelectedPath = new global::Reactive.Bindings.ReactiveProperty<IReadOnlyList<ISection>>([settings, profile]);
+        RootLevel = new SectionLevel([home, settings], settings, section => SelectedSection.Value = section);
+        ChildLevels = new global::Reactive.Bindings.ReactiveProperty<IReadOnlyList<SectionLevel>>([
+            new SectionLevel([profile, preferences], profile, section => SelectedSection.Value = section),
+        ]);
     }
 
     public void GoToSection(string sectionName)
@@ -23,5 +27,8 @@ public class ShellDesign : IShell
     }
 
     public IEnumerable<ISection> Sections { get; }
+    public SectionLevel RootLevel { get; }
+    public global::Reactive.Bindings.ReactiveProperty<IReadOnlyList<SectionLevel>> ChildLevels { get; }
     public global::Reactive.Bindings.ReactiveProperty<ISection> SelectedSection { get; }
+    public global::Reactive.Bindings.ReactiveProperty<IReadOnlyList<ISection>> SelectedPath { get; }
 }

--- a/src/Zafiro.Avalonia/Controls/Shell/ShellView.axaml
+++ b/src/Zafiro.Avalonia/Controls/Shell/ShellView.axaml
@@ -7,7 +7,7 @@
              xmlns:local="clr-namespace:Zafiro.Avalonia.Controls.Shell"
              xmlns:zac="clr-namespace:Zafiro.Avalonia.Controls"
              mc:Ignorable="d" d:DesignWidth="900" d:DesignHeight="600"
-             x:Class="Zafiro.Avalonia.Controls.Shell.ShellView" x:DataType="shell:IShell">
+             x:Class="Zafiro.Avalonia.Controls.Shell.ShellView" x:DataType="shell:IHierarchicalShell">
 
     <Design.DataContext>
         <local:ShellDesign />
@@ -44,17 +44,34 @@
             <!-- Section navigation: bottom bar on mobile, sidebar on desktop -->
             <zac:SectionStrip x:Name="ShellSectionStrip"
                               FlexPanel.Shrink="0"
-                              Sections="{Binding Sections}"
-                              SelectedSection="{Binding SelectedSection.Value, Mode=TwoWay}" />
+                              Sections="{Binding RootLevel.Sections}"
+                              SelectedSection="{Binding RootLevel.SelectedSection.Value, Mode=TwoWay}" />
 
             <!-- Content -->
-            <Frame FlexPanel.Grow="1"
-                   Content="{Binding SelectedSection.Value.Navigator.Content^}"
-                   BackCommand="{Binding SelectedSection.Value.Navigator.Back}">
-                <Interaction.Behaviors>
-                    <nav:AutoHeaderFooterBehavior />
-                </Interaction.Behaviors>
-            </Frame>
+            <FlexPanel FlexPanel.Grow="1" Direction="Column" AlignItems="Stretch">
+                <ItemsControl FlexPanel.Shrink="0" ItemsSource="{Binding ChildLevels.Value}">
+                    <ItemsControl.ItemsPanel>
+                        <ItemsPanelTemplate>
+                            <FlexPanel Direction="Column" AlignItems="Stretch" />
+                        </ItemsPanelTemplate>
+                    </ItemsControl.ItemsPanel>
+                    <ItemsControl.ItemTemplate>
+                        <DataTemplate DataType="shell:SectionLevel">
+                            <zac:SectionStrip Orientation="Horizontal"
+                                              Sections="{Binding Sections}"
+                                              SelectedSection="{Binding SelectedSection.Value, Mode=TwoWay}" />
+                        </DataTemplate>
+                    </ItemsControl.ItemTemplate>
+                </ItemsControl>
+
+                <Frame FlexPanel.Grow="1"
+                       Content="{Binding SelectedSection.Value.Navigator.Content^}"
+                       BackCommand="{Binding SelectedSection.Value.Navigator.Back}">
+                    <Interaction.Behaviors>
+                        <nav:AutoHeaderFooterBehavior />
+                    </Interaction.Behaviors>
+                </Frame>
+            </FlexPanel>
         </FlexPanel>
     </Border>
 </UserControl>

--- a/src/Zafiro.Avalonia/Controls/Shell/SimpleSection.cs
+++ b/src/Zafiro.Avalonia/Controls/Shell/SimpleSection.cs
@@ -5,7 +5,7 @@ using Zafiro.UI.Navigation.Sections;
 
 namespace Zafiro.Avalonia.Controls.Shell;
 
-public partial class SimpleSection : ReactiveObject, ISection
+public partial class SimpleSection : ReactiveObject, IHierarchicalSection
 {
     private readonly CompositeDisposable disposable = new();
     [Reactive] private object? content;
@@ -25,6 +25,7 @@ public partial class SimpleSection : ReactiveObject, ISection
     }
 
     public string Id { get; set; } = string.Empty;
+    public string? ParentId { get; set; }
     public string? ShortName { get; set; }
     public string FriendlyName { get; set; } = string.Empty;
     public SectionGroup Group { get; set; } = new();

--- a/src/Zafiro.Avalonia/Zafiro.Avalonia.csproj
+++ b/src/Zafiro.Avalonia/Zafiro.Avalonia.csproj
@@ -26,6 +26,7 @@
 
         <AdditionalFiles Include="**/*.axaml"/>
 
-        <PackageReference Include="Zafiro.UI"/>
+        <ProjectReference Include="$(ZafiroSourceRoot)/src/Zafiro.UI/Zafiro.UI.csproj" Condition="'$(UseLocalZafiroReferences)' == 'true'" />
+        <PackageReference Include="Zafiro.UI" Condition="'$(UseLocalZafiroReferences)' != 'true'" />
     </ItemGroup>
 </Project>

--- a/src/global.json
+++ b/src/global.json
@@ -1,7 +1,0 @@
-{
-  "sdk": {
-    "version": "7.0.100",
-    "rollForward": "latestMinor",
-    "allowPrerelease": true
-  }
-}

--- a/templates/Zafiro.Avalonia.Templates/templates/zafiro-shell/Directory.Packages.props
+++ b/templates/Zafiro.Avalonia.Templates/templates/zafiro-shell/Directory.Packages.props
@@ -22,7 +22,7 @@
     <PackageVersion Include="Zafiro.Avalonia" Version="$(ZafiroAvaloniaVersion)" />
     <PackageVersion Include="Zafiro.Avalonia.Generators" Version="$(ZafiroAvaloniaVersion)" />
     <PackageVersion Include="Zafiro.Avalonia.Icons.Optris" Version="$(ZafiroAvaloniaVersion)" />
-    <PackageVersion Include="Zafiro.UI" Version="47.0.5" />
+    <PackageVersion Include="Zafiro.UI" Version="47.1.0" />
 
     <!-- Logging -->
     <PackageVersion Include="Serilog" Version="4.3.0" />

--- a/test/Zafiro.Avalonia.Tests/EmptyItemsControlTests.cs
+++ b/test/Zafiro.Avalonia.Tests/EmptyItemsControlTests.cs
@@ -1,11 +1,12 @@
 using Avalonia.Controls;
+using Avalonia.Headless.XUnit;
 using Zafiro.Avalonia.Controls;
 
 namespace Zafiro.Avalonia.Tests;
 
 public class EmptyItemsControlTests
 {
-    [Fact]
+    [AvaloniaFact]
     public void Items_control_gets_empty_class_when_no_items()
     {
         var itemsControl = new ItemsControl();
@@ -14,7 +15,7 @@ public class EmptyItemsControlTests
         Assert.Contains(":empty", itemsControl.Classes);
     }
 
-    [Fact]
+    [AvaloniaFact]
     public void Items_control_removes_empty_class_when_item_added()
     {
         var itemsControl = new ItemsControl();

--- a/test/Zafiro.Avalonia.Tests/HierarchicalShellSampleTests.cs
+++ b/test/Zafiro.Avalonia.Tests/HierarchicalShellSampleTests.cs
@@ -1,0 +1,38 @@
+using System.Linq;
+using System.Reactive.Linq;
+using TestApp.Samples.Shell.Hierarchy;
+using TestApp.Samples.Shell.Hierarchy.Sections;
+
+namespace Zafiro.Avalonia.Tests;
+
+public class HierarchicalShellSampleTests
+{
+    [Fact]
+    public void TestApp_sample_defines_three_navigation_levels_from_section_attributes()
+    {
+        using var sample = new HierarchicalShellSampleViewModel();
+
+        Assert.Equal(["workspace", "reports"], sample.Shell.RootLevel.Sections.Select(section => section.Id));
+        Assert.Equal(["workspace", "customers", "active-customers"], sample.Shell.SelectedPath.Value.Select(section => section.Id));
+        Assert.Equal(2, sample.Shell.ChildLevels.Value.Count);
+        Assert.Equal(["customers", "security"], sample.Shell.ChildLevels.Value[0].Sections.Select(section => section.Id));
+        Assert.Equal(["active-customers", "segments"], sample.Shell.ChildLevels.Value[1].Sections.Select(section => section.Id));
+    }
+
+    [Fact]
+    public async Task TestApp_sample_keeps_each_section_navigation_scope()
+    {
+        using var sample = new HierarchicalShellSampleViewModel();
+
+        var activeCustomersNavigator = sample.Shell.SelectedSection.Value.Navigator;
+        await activeCustomersNavigator.Go(typeof(SegmentsViewModel));
+
+        sample.Shell.GoToSection("security");
+        var securityContent = await sample.Shell.SelectedSection.Value.Navigator.Content.FirstAsync();
+        Assert.IsType<SecurityViewModel>(securityContent);
+
+        sample.Shell.GoToSection("active-customers");
+        var activeCustomersContent = await sample.Shell.SelectedSection.Value.Navigator.Content.FirstAsync();
+        Assert.IsType<SegmentsViewModel>(activeCustomersContent);
+    }
+}

--- a/test/Zafiro.Avalonia.Tests/SectionsRegistrationGeneratorTests.cs
+++ b/test/Zafiro.Avalonia.Tests/SectionsRegistrationGeneratorTests.cs
@@ -132,4 +132,68 @@ public class SectionsRegistrationGeneratorTests
 
         Assert.Contains("shortName: \"USR\"", generated);
     }
+
+    [Fact]
+    public void Generator_emits_parent_id_when_section_attribute_provides_it()
+    {
+        const string source = """
+                              using System;
+
+                              namespace Zafiro.UI.Shell.Utils
+                              {
+                                  [AttributeUsage(AttributeTargets.Class)]
+                                  public class SectionAttribute(string? name = null, string? icon = null, int sortIndex = 0, Type? contractType = null) : Attribute
+                                  {
+                                      public string? Name { get; } = name;
+                                      public string? FriendlyName { get; set; }
+                                      public string? ShortName { get; set; }
+                                      public string? ParentId { get; set; }
+                                      public string? Icon { get; } = icon;
+                                      public int SortIndex { get; } = sortIndex;
+                                      public Type? ContractType { get; } = contractType;
+                                  }
+
+                                  [AttributeUsage(AttributeTargets.Class)]
+                                  public class SectionGroupAttribute(string? key = null, string? friendlyName = null) : Attribute
+                                  {
+                                      public string? Key { get; } = key;
+                                      public string? FriendlyName { get; } = friendlyName;
+                                  }
+                              }
+
+                              namespace Demo
+                              {
+                                  [Zafiro.UI.Shell.Utils.Section("users", "mdi-account", 7, ParentId = "admin")]
+                                  public class UsersViewModel
+                                  {
+                                  }
+                              }
+                              """;
+
+        var syntaxTree = CSharpSyntaxTree.ParseText(source);
+        var compilation = CSharpCompilation.Create(
+            assemblyName: "Demo.Assembly",
+            syntaxTrees: [syntaxTree],
+            references:
+            [
+                MetadataReference.CreateFromFile(typeof(object).Assembly.Location),
+                MetadataReference.CreateFromFile(typeof(Attribute).Assembly.Location),
+                MetadataReference.CreateFromFile(typeof(Enumerable).Assembly.Location),
+                MetadataReference.CreateFromFile(Assembly.Load("System.Runtime").Location)
+            ],
+            options: new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+
+        GeneratorDriver driver = CSharpGeneratorDriver.Create(new SectionsRegistrationGenerator());
+        driver = driver.RunGeneratorsAndUpdateCompilation(compilation, out _, out _);
+
+        var generated = driver.GetRunResult()
+            .Results
+            .Single()
+            .GeneratedSources
+            .Single(sourceResult => sourceResult.HintName == "GeneratedSectionRegistrations.g.cs")
+            .SourceText
+            .ToString();
+
+        Assert.Contains("parentId: \"admin\"", generated);
+    }
 }

--- a/test/Zafiro.Avalonia.Tests/SlimWizardScenarioTests.cs
+++ b/test/Zafiro.Avalonia.Tests/SlimWizardScenarioTests.cs
@@ -148,8 +148,10 @@ public class SlimWizardScenarioTests
 
         var completion = wizard.Navigate(navigator);
 
-        await WaitUntilAsync(() => current is ISlimWizard, TimeSpan.FromSeconds(2));
-        Assert.IsType<SlimWizard<string>>(current);
+        await WaitUntilAsync(
+            () => current is NavigationWizardHost host && ReferenceEquals(host.Wizard, wizard),
+            TimeSpan.FromSeconds(2));
+        Assert.IsType<NavigationWizardHost>(current);
 
         ((ICommand)wizard.Next).Execute(null);
 
@@ -201,21 +203,21 @@ public class SlimWizardScenarioTests
         var completion = parentWizard.Navigate(navigator);
 
         await WaitUntilAsync(
-            () => current is ISlimWizard w && ReferenceEquals(w, parentWizard),
+            () => current is NavigationWizardHost host && ReferenceEquals(host.Wizard, parentWizard),
             TimeSpan.FromSeconds(2));
 
         var parentNextExecution = parentWizard.TypedNext.Execute().ToTask();
 
         await WaitUntilAsync(
             () => childWizard is not null
-                  && current is ISlimWizard w
-                  && ReferenceEquals(w, childWizard),
+                  && current is NavigationWizardHost childHost
+                  && ReferenceEquals(childHost.Wizard, childWizard),
             TimeSpan.FromSeconds(2));
 
         ((ICommand)childWizard!.Next).Execute(null);
 
         await WaitUntilAsync(
-            () => current is ISlimWizard w && ReferenceEquals(w, parentWizard),
+            () => current is NavigationWizardHost host && ReferenceEquals(host.Wizard, parentWizard),
             TimeSpan.FromSeconds(2));
 
         var parentNextResult = await parentNextExecution;

--- a/test/Zafiro.Avalonia.Tests/Zafiro.Avalonia.Tests.csproj
+++ b/test/Zafiro.Avalonia.Tests/Zafiro.Avalonia.Tests.csproj
@@ -30,6 +30,7 @@
         <ProjectReference Include="..\..\src\Zafiro.Avalonia\Zafiro.Avalonia.csproj" />
         <ProjectReference Include="..\..\src\Zafiro.Avalonia.Dialogs\Zafiro.Avalonia.Dialogs.csproj" />
         <ProjectReference Include="..\..\src\Zafiro.Avalonia.Generators\Zafiro.Avalonia.Generators.csproj"/>
+        <ProjectReference Include="..\..\samples\TestApp\TestApp\TestApp.csproj" />
     </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Adds automatic hierarchical shell section rendering on top of the new Zafiro.UI hierarchy contracts.\n\nKey points:\n- Uses Zafiro.UI 47.1.0 from NuGet by default.\n- Removes the Zafiro submodule and keeps local cross-repo iteration opt-in via UseLocalZafiroReferences/ZafiroSourceRoot.\n- Extends ShellView to render root sections plus child section levels.\n- Adds a TestApp hierarchical shell sample and tests covering generated attributes and navigation preservation.\n- Keeps dotnet format from resolving the stale SDK 7 global.json by removing src/global.json.